### PR TITLE
Fix Bug 614032 (delete property initializer)

### DIFF
--- a/lib/jsdefs.js
+++ b/lib/jsdefs.js
@@ -264,7 +264,7 @@ Narcissus.definitions = (function() {
             defineProperty: function(name, desc) {
                 Object.defineProperty(obj, name, desc);
             },
-            delete: function(name) { return delete obj[name]; },
+            "delete": function(name) { return delete obj[name]; },
             fix: function() {
                 if (Object.isFrozen(obj)) {
                     return getOwnProperties(obj);


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=614032 . Some versions of V8 can't parse "delete" as the LHS of a property initializer.
