### PR TITLE
Functional static context

### DIFF
--- a/lib/jsdefs.js
+++ b/lib/jsdefs.js
@@ -296,6 +296,70 @@ Narcissus.definitions = (function() {
     // default function used when looking for a property in the global object
     function noPropFound() { return undefined; }
 
+    var hasOwnProperty = ({}).hasOwnProperty;
+
+    function StringMap() {
+        this.table = Object.create(null, {});
+        this.size = 0;
+    }
+
+    StringMap.prototype = {
+        has: function(x) { return hasOwnProperty.call(this.table, x); },
+        set: function(x, v) {
+            if (!hasOwnProperty.call(this.table, x))
+                this.size++;
+            this.table[x] = v;
+        },
+        get: function(x) { return this.table[x]; },
+        getDef: function(x, thunk) {
+            if (!hasOwnProperty.call(this.table, x)) {
+                this.size++;
+                this.table[x] = thunk();
+            }
+            return this.table[x];
+        },
+        forEach: function(f) {
+            var table = this.table;
+            for (var key in table)
+                f.call(this, key, table[key]);
+        },
+        toString: function() { return "[object StringMap]" }
+    };
+
+    // non-destructive stack
+    function Stack(elts) {
+        this.elts = elts || null;
+    }
+
+    Stack.prototype = {
+        push: function(x) {
+            return new Stack({ top: x, rest: this.elts });
+        },
+        top: function() {
+            if (!this.elts)
+                throw new Error("empty stack");
+            return this.elts.top;
+        },
+        isEmpty: function() {
+            return this.top === null;
+        },
+        find: function(test) {
+            for (var elts = this.elts; elts; elts = elts.rest) {
+                if (test(elts.top))
+                    return elts.top;
+            }
+            return null;
+        },
+        has: function(x) {
+            return Boolean(this.find(function(elt) { return elt === x }));
+        },
+        forEach: function(f) {
+            for (var elts = this.elts; elts; elts = elts.rest) {
+                f(elts.top);
+            }
+        }
+    };
+
     return {
         tokens: tokens,
         opTypeNames: opTypeNames,
@@ -308,6 +372,8 @@ Narcissus.definitions = (function() {
         defineProperty: defineProperty,
         isNativeCode: isNativeCode,
         makePassthruHandler: makePassthruHandler,
-        noPropFound: noPropFound
+        noPropFound: noPropFound,
+        StringMap: StringMap,
+        Stack: Stack
     };
 }());

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -558,7 +558,7 @@ Narcissus.interpreter = (function() {
           case LABEL:
             try {
                 execute(n.statement, x);
-            } catch (e if e === BREAK && x.target === n) {
+            } catch (e if e === BREAK && x.target === n.target) {
             }
             break;
 
@@ -1090,6 +1090,23 @@ Narcissus.interpreter = (function() {
         return x.result;
     }
 
+    function printStackTrace(stack) {
+        var st = String(stack).split(/\n/);
+        // beautify stack trace:
+        //   - eliminate blank lines
+        //   - sanitize confusing trace lines for getters and js -e expressions
+        //   - simplify source location reporting
+        //   - indent
+        for (var i = 0; i < st.length; i++) {
+            var line = st[i].trim();
+            if (line) {
+                line = line.replace(/^(\(\))?@/, "<unknown>@");
+                line = line.replace(/@(.*\/|\\)?([^\/\\]+:[0-9]+)/, " at $2");
+                print("    in " + line);
+            }
+        }
+    }
+
     // A read-eval-print-loop that roughly tracks the behavior of the js shell.
     function repl() {
 
@@ -1152,38 +1169,32 @@ Narcissus.interpreter = (function() {
                 print(PREFIX + e.toString());
                 print(PREFIX + e.source);
                 print(PREFIX + ".".repeat(e.cursor) + "^");
-            } catch (e) {
-                if (!(e instanceof Error)) {
-                    print("unexpected Narcissus exception (" + e + ")");
-                    throw e;
-                }
-
+            } catch (e if e instanceof Error) {
                 print((e.filename || "stdin") + ":" +  e.lineNumber + ": " + e.toString());
-                if (e.stack) {
-                    let st = String(e.stack).split(/\n/);
-
-                    // Beautify stack trace:
-                    //   - eliminate blank lines
-                    //   - sanitize confusing trace lines for getters and js -e expressions
-                    //   - simplify source location reporting
-                    //   - indent
-                    for (let i = 0; i < st.length; i++) {
-                        let line = st[i].trim();
-                        line = line.replace(/^(\(\))?@/, "<unknown>@");
-                        line = line.replace(/\[object (\w+)]/g, "$1");
-                        line = line.replace(/@(.*\/|\\)?([^\/\\]+:[0-9]+)/, " at $2");
-                        print("    in " + line);
-                    }
-                }
+                if (e.stack)
+                    printStackTrace(e.stack);
+            } catch (e) {
+                print("unexpected Narcissus exception (" + e + ")");
+                throw e;
             }
         }
         ExecutionContext.current = null;
     }
 
+    function test(thunk) {
+        try {
+            return thunk();
+        } catch (e) {
+            print(e.fileName + ":" + e.lineNumber + ": " + e.name + ": " + e.message);
+            printStackTrace(e.stack);
+        }
+    }
+
     return {
         global: global,
         evaluate: evaluate,
-        repl: repl
+        repl: repl,
+        test: test
     };
 
 }());

--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -54,64 +54,103 @@ Narcissus.parser = (function() {
     var lexer = Narcissus.lexer;
     var definitions = Narcissus.definitions;
 
+    const StringMap = definitions.StringMap;
+    const Stack = definitions.Stack;
+
     // Set constants in the local scope.
     eval(definitions.consts);
 
     /*
+     * pushDestructuringVarDecls :: (node, hoisting node) -> void
+     *
      * Recursively add all destructured declarations to varDecls.
      */
-    function pushDestructuringVarDecls(n, x) {
+    function pushDestructuringVarDecls(n, s) {
         for (var i in n) {
             var sub = n[i];
             if (sub.type === IDENTIFIER) {
-                x.varDecls.push(sub);
+                s.varDecls.push(sub);
             } else {
-                pushDestructuringVarDecls(sub, x);
+                pushDestructuringVarDecls(sub, s);
             }
         }
     }
 
-    function StaticContext(inFunction) {
+    // NESTING_TOP: top-level
+    // NESTING_SHALLOW: nested within static forms such as { ... } or labeled statement
+    // NESTING_DEEP: nested within dynamic forms such as if, loops, etc.
+    const NESTING_TOP = 0, NESTING_SHALLOW = 1, NESTING_DEEP = 2;
+
+    function StaticContext(parentScript, parentBlock, inFunction, inForLoopInit, nesting) {
+        this.parentScript = parentScript;
+        this.parentBlock = parentBlock;
         this.inFunction = inFunction;
-        this.hasEmptyReturn = false;
-        this.hasReturnWithValue = false;
-        this.isGenerator = false;
-        this.stmtStack = [];
-        this.funDecls = [];
-        this.varDecls = [];
+        this.inForLoopInit = inForLoopInit;
+        this.nesting = nesting;
+        this.allLabels = new Stack();
+        this.currentLabels = new Stack();
+        this.labeledTargets = new Stack();
+        this.defaultTarget = null;
         Narcissus.options.ecma3OnlyMode && (this.ecma3OnlyMode = true);
         Narcissus.options.parenFreeMode && (this.parenFreeMode = true);
     }
 
     StaticContext.prototype = {
-        bracketLevel: 0,
-        curlyLevel: 0,
-        parenLevel: 0,
-        hookLevel: 0,
-        inForLoopInit: false,
         ecma3OnlyMode: false,
         parenFreeMode: false,
-        maybeMatchLeftParen: function (t) {
-            if (this.parenFreeMode)
-               return t.match(LEFT_PAREN) ? LEFT_PAREN : END;
-            return t.mustMatch(LEFT_PAREN).type;
+        // non-destructive update via prototype extension
+        update: function(ext) {
+            var desc = {};
+            for (var key in ext) {
+                desc[key] = {
+                    value: ext[key],
+                    writable: true,
+                    enumerable: true,
+                    configurable: true
+                }
+            }
+            return Object.create(this, desc);
         },
-        maybeMatchRightParen: function (t, p) {
-            if (p === LEFT_PAREN)
-                t.mustMatch(RIGHT_PAREN);
+        pushLabel: function(label) {
+            return this.update({ currentLabels: this.currentLabels.push(label),
+                                 allLabels: this.allLabels.push(label) });
         },
+        pushTarget: function(target) {
+            var isDefaultTarget = target.isLoop || target.type === SWITCH;
+
+            if (this.currentLabels.isEmpty()) {
+                return isDefaultTarget
+                     ? this.update({ defaultTarget: target })
+                     : this;
+            }
+
+            target.labels = new StringMap();
+            this.currentLabels.forEach(function(label) {
+                target.labels.set(label, true);
+            });
+            return this.update({ currentLabels: new Stack(),
+                                 labeledTargets: this.labeledTargets.push(target),
+                                 defaultTarget: isDefaultTarget
+                                                ? target
+                                                : this.defaultTarget });
+        },
+        nest: function(atLeast) {
+            var nesting = Math.max(this.nesting, atLeast);
+            return (nesting !== this.nesting)
+                 ? this.update({ nesting: nesting })
+                 : this;
+        }
     };
 
     /*
-     * Script :: (tokenizer, compiler context) -> node
+     * Script :: (tokenizer, boolean) -> node
      *
      * Parses the toplevel and function bodies.
      */
-    function Script(t, x) {
-        var n = Statements(t, x);
-        n.type = SCRIPT;
-        n.funDecls = x.funDecls;
-        n.varDecls = x.varDecls;
+    function Script(t, inFunction) {
+        var n = new Node(t, scriptInit());
+        var x = new StaticContext(n, n, inFunction, false, NESTING_TOP);
+        Statements(t, x, n);
         return n;
     }
 
@@ -195,8 +234,24 @@ Narcissus.parser = (function() {
      * Helper init objects for common nodes.
      */
 
-    const BLOCK_INIT = { type: BLOCK, varDecls: [] };
     const LOOP_INIT = { isLoop: true };
+
+    function blockInit() {
+        return { type: BLOCK, varDecls: [] };
+    }
+
+    function scriptInit() {
+        return { type: SCRIPT,
+                 funDecls: [],
+                 varDecls: [],
+                 modDecls: [],
+                 impDecls: [],
+                 expDecls: [],
+                 loadDeps: [],
+                 hasEmptyReturn: false,
+                 hasReturnWithValue: false,
+                 isGenerator: false };
+    }
 
     definitions.defineGetter(Np, "filename",
                              function() {
@@ -217,23 +272,23 @@ Narcissus.parser = (function() {
                                    return s;
                                }, false, false, true);
 
-    // Statement stack and nested statement handler.
-    function nest(t, x, node, func, end) {
-        x.stmtStack.push(node);
-        var n = func(t, x);
-        x.stmtStack.pop();
-        end && t.mustMatch(end);
-        return n;
+    function MaybeLeftParen(t, x) {
+        if (x.parenFreeMode)
+            return t.match(LEFT_PAREN) ? LEFT_PAREN : END;
+        return t.mustMatch(LEFT_PAREN).type;
+    }
+
+    function MaybeRightParen(t, p) {
+        if (p === LEFT_PAREN)
+            t.mustMatch(RIGHT_PAREN);
     }
 
     /*
-     * Statements :: (tokenizer, compiler context) -> node
+     * Statements :: (tokenizer, compiler context, node) -> void
      *
-     * Parses a list of Statements.
+     * Parses a sequence of Statements.
      */
-    function Statements(t, x) {
-        var n = new Node(t, BLOCK_INIT);
-        x.stmtStack.push(n);
+    function Statements(t, x, n) {
         try {
             while (!t.done && t.peek(true) !== RIGHT_CURLY)
                 n.push(Statement(t, x));
@@ -242,13 +297,12 @@ Narcissus.parser = (function() {
                 t.unexpectedEOF = true;
             throw e;
         }
-        x.stmtStack.pop();
-        return n;
     }
 
     function Block(t, x) {
         t.mustMatch(LEFT_CURLY);
-        var n = Statements(t, x);
+        var n = new Node(t, blockInit());
+        Statements(t, x.update({ parentBlock: n }).pushTarget(n), n);
         t.mustMatch(RIGHT_CURLY);
         return n;
     }
@@ -261,7 +315,7 @@ Narcissus.parser = (function() {
      * Parses a Statement.
      */
     function Statement(t, x) {
-        var i, label, n, n2, p, c, ss, tt = t.get(true), tt2;
+        var i, label, n, n2, p, c, ss, tt = t.get(true), tt2, x2, x3;
 
         // Cases for statements ending in a right curly return early, avoiding the
         // common semicolon insertion magic after this switch.
@@ -269,29 +323,29 @@ Narcissus.parser = (function() {
           case FUNCTION:
             // DECLARED_FORM extends funDecls of x, STATEMENT_FORM doesn't.
             return FunctionDefinition(t, x, true,
-                                      (x.stmtStack.length > 1)
+                                      (x.nesting !== NESTING_TOP)
                                       ? STATEMENT_FORM
                                       : DECLARED_FORM);
 
           case LEFT_CURLY:
-            n = Statements(t, x);
+            n = new Node(t, blockInit());
+            Statements(t, x.update({ parentBlock: n }).pushTarget(n).nest(NESTING_SHALLOW), n);
             t.mustMatch(RIGHT_CURLY);
             return n;
 
           case IF:
             n = new Node(t);
             n.condition = HeadExpression(t, x);
-            x.stmtStack.push(n);
-            n.thenPart = Statement(t, x);
-            n.elsePart = t.match(ELSE) ? Statement(t, x) : null;
-            x.stmtStack.pop();
+            x2 = x.pushTarget(n).nest(NESTING_DEEP);
+            n.thenPart = Statement(t, x2);
+            n.elsePart = t.match(ELSE) ? Statement(t, x2) : null;
             return n;
 
           case SWITCH:
             // This allows CASEs after a DEFAULT, which is in the standard.
             n = new Node(t, { cases: [], defaultIndex: -1 });
             n.discriminant = HeadExpression(t, x);
-            x.stmtStack.push(n);
+            x2 = x.pushTarget(n).nest(NESTING_DEEP);
             t.mustMatch(LEFT_CURLY);
             while ((tt = t.get()) !== RIGHT_CURLY) {
                 switch (tt) {
@@ -304,54 +358,55 @@ Narcissus.parser = (function() {
                     if (tt === DEFAULT)
                         n.defaultIndex = n.cases.length;
                     else
-                        n2.caseLabel = Expression(t, x, COLON);
+                        n2.caseLabel = Expression(t, x2, COLON);
                     break;
 
                   default:
                     throw t.newSyntaxError("Invalid switch case");
                 }
                 t.mustMatch(COLON);
-                n2.statements = new Node(t, BLOCK_INIT);
+                n2.statements = new Node(t, blockInit());
                 while ((tt=t.peek(true)) !== CASE && tt !== DEFAULT &&
                         tt !== RIGHT_CURLY)
-                    n2.statements.push(Statement(t, x));
+                    n2.statements.push(Statement(t, x2));
                 n.cases.push(n2);
             }
-            x.stmtStack.pop();
             return n;
 
           case FOR:
             n = new Node(t, LOOP_INIT);
-            if (t.match(IDENTIFIER) && t.token.value === "each")
-                n.isEach = true;
-            else
-                t.unget();
+            if (t.match(IDENTIFIER)) {
+                if (t.token.value === "each")
+                    n.isEach = true;
+                else
+                    t.unget();
+            }
             if (!x.parenFreeMode)
                 t.mustMatch(LEFT_PAREN);
+            x2 = x.pushTarget(n).nest(NESTING_DEEP);
+            x3 = x.update({ inForLoopInit: true });
             if ((tt = t.peek()) !== SEMICOLON) {
-                x.inForLoopInit = true;
                 if (tt === VAR || tt === CONST) {
                     t.get();
-                    n2 = Variables(t, x);
+                    n2 = Variables(t, x3);
                 } else if (tt === LET) {
                     t.get();
                     if (t.peek() === LEFT_PAREN) {
-                        n2 = LetBlock(t, x, false);
+                        n2 = LetBlock(t, x3, false);
                     } else {
                         // Let in for head, we need to add an implicit block
                         // around the rest of the for.
-                        var forBlock = new Node(t, BLOCK_INIT);
-                        x.stmtStack.push(forBlock);
-                        n2 = Variables(t, x, forBlock);
+                        x3.parentBlock = n;
+                        n.varDecls = [];
+                        n2 = Variables(t, x3);
                     }
                 } else {
-                    n2 = Expression(t, x);
+                    n2 = Expression(t, x3);
                 }
-                x.inForLoopInit = false;
             }
             if (n2 && t.match(IN)) {
                 n.type = FOR_IN;
-                n.object = Expression(t, x);
+                n.object = Expression(t, x3);
                 if (n2.type === VAR || n2.type === LET) {
                     c = n2.children;
 
@@ -370,7 +425,7 @@ Narcissus.parser = (function() {
                     n.varDecl = n2;
                 } else {
                     if (n2.type === ARRAY_INIT || n2.type === OBJECT_INIT) {
-                        n2.destructuredNames = checkDestructuring(t, x, n2);
+                        n2.destructuredNames = checkDestructuring(t, x3, n2);
                     }
                     n.iterator = n2;
                 }
@@ -381,32 +436,30 @@ Narcissus.parser = (function() {
                     throw t.newSyntaxError("Invalid for each..in loop");
                 n.condition = (t.peek() === SEMICOLON)
                               ? null
-                              : Expression(t, x);
+                              : Expression(t, x3);
                 t.mustMatch(SEMICOLON);
                 tt2 = t.peek();
                 n.update = (x.parenFreeMode
                             ? tt2 === LEFT_CURLY || definitions.isStatementStartCode[tt2]
                             : tt2 === RIGHT_PAREN)
                            ? null
-                           : Expression(t, x);
+                           : Expression(t, x3);
             }
             if (!x.parenFreeMode)
                 t.mustMatch(RIGHT_PAREN);
-            n.body = nest(t, x, n, Statement);
-            if (forBlock)
-                x.stmtStack.pop();
-
+            n.body = Statement(t, x2);
             return n;
 
           case WHILE:
             n = new Node(t, { isLoop: true });
             n.condition = HeadExpression(t, x);
-            n.body = nest(t, x, n, Statement);
+            n.body = Statement(t, x.pushTarget(n).nest(NESTING_DEEP));
             return n;
 
           case DO:
             n = new Node(t, { isLoop: true });
-            n.body = nest(t, x, n, Statement, WHILE);
+            n.body = Statement(t, x.pushTarget(n).nest(NESTING_DEEP));
+            t.mustMatch(WHILE);
             n.condition = HeadExpression(t, x);
             if (!x.ecmaStrictMode) {
                 // <script language="JavaScript"> (without version hints) may need
@@ -421,42 +474,23 @@ Narcissus.parser = (function() {
           case CONTINUE:
             n = new Node(t);
 
+            // handle the |foo: break foo;| corner case
+            x2 = x.pushTarget(n);
+
             if (t.peekOnSameLine() === IDENTIFIER) {
                 t.get();
                 n.label = t.token.value;
             }
 
-            ss = x.stmtStack;
-            i = ss.length;
-            label = n.label;
+            n.target = n.label
+                     ? x2.labeledTargets.find(function(target) { return target.labels.has(n.label) })
+                     : x2.defaultTarget;
 
-            if (label) {
-                do {
-                    if (--i < 0)
-                        throw t.newSyntaxError("Label not found");
-                } while (ss[i].label !== label);
+            if (!n.target)
+                throw t.newSyntaxError("Invalid " + ((tt === BREAK) ? "break" : "continue"));
+            if (!n.target.isLoop && tt === CONTINUE)
+                throw t.newSyntaxError("Invalid continue");
 
-                // Both break and continue to label need to be handled specially
-                // within a labeled loop, so that they target that loop. If not in
-                // a loop, then break targets its labeled statement. Labels can be
-                // nested so we skip all labels immediately enclosing the nearest
-                // non-label statement.
-                while (i < ss.length - 1 && ss[i+1].type === LABEL)
-                    i++;
-                if (i < ss.length - 1 && ss[i+1].isLoop)
-                    i++;
-                else if (tt === CONTINUE)
-                    throw t.newSyntaxError("Invalid continue");
-            } else {
-                do {
-                    if (--i < 0) {
-                        throw t.newSyntaxError("Invalid " + ((tt === BREAK)
-                                                             ? "break"
-                                                             : "continue"));
-                    }
-                } while (!ss[i].isLoop && !(tt === BREAK && ss[i].type === SWITCH));
-            }
-            n.target = ss[i];
             break;
 
           case TRY:
@@ -464,7 +498,7 @@ Narcissus.parser = (function() {
             n.tryBlock = Block(t, x);
             while (t.match(CATCH)) {
                 n2 = new Node(t);
-                p = x.maybeMatchLeftParen(t);
+                p = MaybeLeftParen(t, x);
                 switch (t.get()) {
                   case LEFT_BRACKET:
                   case LEFT_CURLY:
@@ -486,7 +520,7 @@ Narcissus.parser = (function() {
                         throw t.newSyntaxError("Guarded catch after unguarded");
                     n2.guard = Expression(t, x);
                 }
-                x.maybeMatchRightParen(t, p);
+                MaybeRightParen(t, p);
                 n2.block = Block(t, x);
                 n.catchClauses.push(n2);
             }
@@ -512,7 +546,7 @@ Narcissus.parser = (function() {
           case WITH:
             n = new Node(t);
             n.object = HeadExpression(t, x);
-            n.body = nest(t, x, n, Statement);
+            n.body = Statement(t, x.pushTarget(n).nest(NESTING_DEEP));
             return n;
 
           case VAR:
@@ -543,14 +577,12 @@ Narcissus.parser = (function() {
                 // Labeled statement.
                 if (tt === COLON) {
                     label = t.token.value;
-                    ss = x.stmtStack;
-                    for (i = ss.length-1; i >= 0; --i) {
-                        if (ss[i].label === label)
-                            throw t.newSyntaxError("Duplicate label");
-                    }
+                    if (x.allLabels.has(label))
+                        throw t.newSyntaxError("Duplicate label");
                     t.get();
                     n = new Node(t, { type: LABEL, label: label });
-                    n.statement = nest(t, x, n, Statement);
+                    n.statement = Statement(t, x.pushLabel(label).nest(NESTING_SHALLOW));
+                    n.target = (n.statement.type === LABEL) ? n.statement.target : n.statement;
                     return n;
                 }
             }
@@ -581,13 +613,15 @@ Narcissus.parser = (function() {
     function ReturnOrYield(t, x) {
         var n, b, tt = t.token.type, tt2;
 
+        var parentScript = x.parentScript;
+
         if (tt === RETURN) {
             if (!x.inFunction)
                 throw t.newSyntaxError("Return not in function");
         } else /* if (tt === YIELD) */ {
             if (!x.inFunction)
                 throw t.newSyntaxError("Yield not in function");
-            x.isGenerator = true;
+            parentScript.isGenerator = true;
         }
         n = new Node(t, { value: undefined });
 
@@ -599,16 +633,16 @@ Narcissus.parser = (function() {
                  tt2 !== COLON && tt2 !== COMMA))) {
             if (tt === RETURN) {
                 n.value = Expression(t, x);
-                x.hasReturnWithValue = true;
+                parentScript.hasReturnWithValue = true;
             } else {
                 n.value = AssignExpression(t, x);
             }
         } else if (tt === RETURN) {
-            x.hasEmptyReturn = true;
+            parentScript.hasEmptyReturn = true;
         }
 
         // Disallow return v; in generator.
-        if (x.hasReturnWithValue && x.isGenerator)
+        if (parentScript.hasReturnWithValue && parentScript.isGenerator)
             throw t.newSyntaxError("Generator returns a value");
 
         return n;
@@ -620,7 +654,7 @@ Narcissus.parser = (function() {
      *                    -> node
      */
     function FunctionDefinition(t, x, requireName, functionForm) {
-        var tt, x2;
+        var tt;
         var f = new Node(t, { params: [] });
         if (f.type !== FUNCTION)
             f.type = (f.value === "get") ? GETTER : SETTER;
@@ -629,7 +663,7 @@ Narcissus.parser = (function() {
         else if (requireName)
             throw t.newSyntaxError("missing function identifier");
 
-        x2 = new StaticContext(true);
+        var x2 = new StaticContext(null, null, true, false, NESTING_TOP);
 
         t.mustMatch(LEFT_PAREN);
         if (!t.match(RIGHT_PAREN)) {
@@ -659,10 +693,10 @@ Narcissus.parser = (function() {
 
         if (tt !== LEFT_CURLY) {
             f.body = AssignExpression(t, x2);
-            if (x2.isGenerator)
+            if (f.body.isGenerator)
                 throw t.newSyntaxError("Generator returns a value");
         } else {
-            f.body = Script(t, x2);
+            f.body = Script(t, true);
         }
 
         if (tt === LEFT_CURLY)
@@ -671,7 +705,7 @@ Narcissus.parser = (function() {
         f.end = t.token.end;
         f.functionForm = functionForm;
         if (functionForm === DECLARED_FORM)
-            x.funDecls.push(f);
+            x.parentScript.funDecls.push(f);
         return f;
     }
 
@@ -687,28 +721,15 @@ Narcissus.parser = (function() {
         tt = t.token.type;
         switch (tt) {
           case VAR:
-            s = x;
-            break;
           case CONST:
-            s = x;
+            s = x.parentScript;
             break;
           case LET:
+            s = x.parentBlock;
+            break;
           case LEFT_PAREN:
             tt = LET;
-            if (!letBlock) {
-                ss = x.stmtStack;
-                i = ss.length;
-                while (ss[--i].type !== BLOCK) ; // a BLOCK *must* be found.
-                // Lets at the function toplevel are just vars, at least in
-                // SpiderMonkey.
-                if (i === 0) {
-                    s = x;
-                } else {
-                    s = ss[i];
-                }
-            } else {
-                s = letBlock;
-            }
+            s = letBlock;
             break;
         }
 
@@ -720,7 +741,7 @@ Narcissus.parser = (function() {
                 // Need to unget to parse the full destructured expression.
                 t.unget();
 
-                var dexp = DestructuringExpression(t, x, true, s);
+                var dexp = DestructuringExpression(t, x, true);
 
                 n2 = new Node(t, { type: IDENTIFIER,
                                    name: dexp,
@@ -795,7 +816,7 @@ Narcissus.parser = (function() {
         return n;
     }
 
-    function checkDestructuring(t, x, n, simpleNamesOnly, data) {
+    function checkDestructuring(t, x, n, simpleNamesOnly) {
         if (n.type === ARRAY_COMP)
             throw t.newSyntaxError("Invalid array comprehension left-hand side");
         if (n.type !== ARRAY_INIT && n.type !== OBJECT_INIT)
@@ -820,8 +841,7 @@ Narcissus.parser = (function() {
             }
 
             if (sub.type === ARRAY_INIT || sub.type === OBJECT_INIT) {
-                lhss[idx] = checkDestructuring(t, x, sub,
-                                               simpleNamesOnly, data);
+                lhss[idx] = checkDestructuring(t, x, sub, simpleNamesOnly);
             } else {
                 if (simpleNamesOnly && sub.type !== IDENTIFIER) {
                     // In declarations, lhs must be simple names
@@ -835,11 +855,10 @@ Narcissus.parser = (function() {
         return lhss;
     }
 
-    function DestructuringExpression(t, x, simpleNamesOnly, data) {
+    function DestructuringExpression(t, x, simpleNamesOnly) {
         var n = PrimaryExpression(t, x);
         // Keep the list of lefthand sides for varDecls
-        n.destructuredNames = checkDestructuring(t, x, n,
-                                                 simpleNamesOnly, data);
+        n.destructuredNames = checkDestructuring(t, x, n, simpleNamesOnly);
         return n;
     }
 
@@ -865,7 +884,7 @@ Narcissus.parser = (function() {
                 else
                     t.unget();
             }
-            p = x.maybeMatchLeftParen(t);
+            p = MaybeLeftParen(t, x);
             switch(t.get()) {
               case LEFT_BRACKET:
               case LEFT_CURLY:
@@ -879,7 +898,7 @@ Narcissus.parser = (function() {
                 n3.name = n3.value;
                 n.varDecl = n2 = new Node(t, { type: VAR });
                 n2.push(n3);
-                x.varDecls.push(n3);
+                x.parentScript.varDecls.push(n3);
                 // Don't add to varDecls since the semantics of comprehensions is
                 // such that the variables are in their own function when
                 // desugared.
@@ -890,7 +909,7 @@ Narcissus.parser = (function() {
             }
             t.mustMatch(IN);
             n.object = Expression(t, x);
-            x.maybeMatchRightParen(t, p);
+            MaybeRightParen(t, p);
             body.push(n);
         } while (t.match(FOR));
 
@@ -902,9 +921,9 @@ Narcissus.parser = (function() {
     }
 
     function HeadExpression(t, x) {
-        var p = x.maybeMatchLeftParen(t);
+        var p = MaybeLeftParen(t, x);
         var n = ParenExpression(t, x);
-        x.maybeMatchRightParen(t, p);
+        MaybeRightParen(t, p);
         if (p === END && !n.parenthesized) {
             var tt = t.peek();
             if (tt !== LEFT_CURLY && !definitions.isStatementStartCode[tt])
@@ -917,10 +936,8 @@ Narcissus.parser = (function() {
         // Always accept the 'in' operator in a parenthesized expression,
         // where it's unambiguous, even if we might be parsing the init of a
         // for statement.
-        var oldLoopInit = x.inForLoopInit;
-        x.inForLoopInit = (t.token.type === LEFT_PAREN);
-        var n = Expression(t, x);
-        x.inForLoopInit = oldLoopInit;
+        var n = Expression(t, x.update({ inForLoopInit: x.inForLoopInit &&
+                                                        (t.token.type === LEFT_PAREN) }));
 
         if (t.match(FOR)) {
             if (n.type === YIELD && !n.parenthesized)
@@ -1004,10 +1021,7 @@ Narcissus.parser = (function() {
              * where it's unambiguous, even if we might be parsing the init of a
              * for statement.
              */
-            var oldLoopInit = x.inForLoopInit;
-            x.inForLoopInit = false;
-            n.push(AssignExpression(t, x));
-            x.inForLoopInit = oldLoopInit;
+            n.push(AssignExpression(t, x.update({ inForLoopInit: false })));
             if (!t.match(COLON))
                 throw t.newSyntaxError("missing : after ?");
             n.push(AssignExpression(t, x));
@@ -1103,23 +1117,21 @@ Narcissus.parser = (function() {
 
     function RelationalExpression(t, x) {
         var n, n2;
-        var oldLoopInit = x.inForLoopInit;
 
         /*
          * Uses of the in operator in shiftExprs are always unambiguous,
          * so unset the flag that prohibits recognizing it.
          */
-        x.inForLoopInit = false;
-        n = ShiftExpression(t, x);
+        var x2 = x.update({ inForLoopInit: false });
+        n = ShiftExpression(t, x2);
         while ((t.match(LT) || t.match(LE) || t.match(GE) || t.match(GT) ||
-               (oldLoopInit === false && t.match(IN)) ||
+               (!x.inForLoopInit && t.match(IN)) ||
                t.match(INSTANCEOF))) {
             n2 = new Node(t);
             n2.push(n);
-            n2.push(ShiftExpression(t, x));
+            n2.push(ShiftExpression(t, x2));
             n = n2;
         }
-        x.inForLoopInit = oldLoopInit;
 
         return n;
     }
@@ -1386,8 +1398,7 @@ Narcissus.parser = (function() {
      */
     function parse(s, f, l) {
         var t = new lexer.Tokenizer(s, f, l);
-        var x = new StaticContext(false);
-        var n = Script(t, x);
+        var n = Script(t, false);
         if (!t.done)
             throw t.newSyntaxError("Syntax error");
 
@@ -1401,8 +1412,7 @@ Narcissus.parser = (function() {
         for (;;) {
             try {
                 var t = new lexer.Tokenizer(s, "stdin", ln.value);
-                var x = new StaticContext(false);
-                var n = Script(t, x);
+                var n = Script(t, false);
                 ln.value = t.lineno;
                 return n;
             } catch (e) {

--- a/tests/narcissus-failures.txt
+++ b/tests/narcissus-failures.txt
@@ -1443,3 +1443,9 @@ narcissus/../ecma/Date/dst-offset-caching-7-of-8.js
 narcissus/../ecma/Date/dst-offset-caching-8-of-8.js
 narcissus/../ecma_3/Date/15.9.5.4.js
 narcissus/../ecma_3/Date/regress-452786.js
+ecma_5/Global/direct-eval-but-not.js
+ecma_5/extensions/watchpoint-deletes-JSPropertyOp-setter.js
+ecma_5/strict/this-for-function-expression-recursion.js
+js1_8_5/regress/regress-595230-1.js
+js1_8_5/regress/regress-609617.js
+js1_8_5/regress/regress-610026.js


### PR DESCRIPTION
Code changes:
- added StringMap and Stack data structures to jsdefs
- moved stack traces to jsdefs
- StaticContext is not mutated but functionally updated
- StaticContext tracks the current var-hoisting context via |parentScript|
- StaticContext tracks the current let-hoisting context via |parentBlock|
- moved funDecls and varDecls out of StaticContext and into the hoisting context
- StaticContext tracks current nesting depth as a constant, rather than implicitly via stmtStack
- StaticContext tracks labels more clearly (no more stmtStack)
- function node flags are stored directly on the function's SCRIPT node, not in the static context
- Statements parser mutates an existing node rather than creating a BLOCK node
- eliminate nest() function (for paired .push()/.pop()) in favor of functional update
- eliminate dead |data| parameter from DestructuringExpression and checkDestructuring

AST changes:
- to handle adjacent nesting (e.g., foo: bar: { ... }), every labeled statement has a "target" field pointing to the first non-labeled descendent
- for-let nodes do not wrap the for loop in an implicit block; they store the local varDecls directly on the FOR node
