### PR TITLE
Narcissus pushes needed for Zaphod

### DIFF
--- a/lib/jsbrowser.js
+++ b/lib/jsbrowser.js
@@ -44,7 +44,7 @@
  */
 
 // Prevent setTimeout from breaking out to SpiderMonkey
-Narcissus.interpreter.global.setTimeout = function(code, delay) {
+Narcissus.interpreter.narcissusGlobalBase.setTimeout = function(code, delay) {
     var timeoutCode = (typeof code === "string") ?
             function() { Narcissus.interpreter.evaluate(code); } :
             code;
@@ -52,7 +52,7 @@ Narcissus.interpreter.global.setTimeout = function(code, delay) {
 };
 
 // Prevent setInterval from breaking out to SpiderMonkey
-Narcissus.interpreter.global.setInterval = function(code, delay) {
+Narcissus.interpreter.narcissusGlobalBase.setInterval = function(code, delay) {
     var timeoutCode = (typeof code === "string") ?
             function() { Narcissus.interpreter.evaluate(code); } :
             code;
@@ -60,6 +60,6 @@ Narcissus.interpreter.global.setInterval = function(code, delay) {
 };
 
 // Hack to avoid problems with the Image constructor in Narcissus.
-Narcissus.interpreter.global.Image = function() {};
+Narcissus.interpreter.narcissusGlobalBase.Image = function() {};
 
 

--- a/lib/jsbrowser.js
+++ b/lib/jsbrowser.js
@@ -44,7 +44,7 @@
  */
 
 // Prevent setTimeout from breaking out to SpiderMonkey
-Narcissus.interpreter.narcissusGlobalBase.setTimeout = function(code, delay) {
+Narcissus.interpreter.globalBase.setTimeout = function(code, delay) {
     var timeoutCode = (typeof code === "string") ?
             function() { Narcissus.interpreter.evaluate(code); } :
             code;
@@ -52,7 +52,7 @@ Narcissus.interpreter.narcissusGlobalBase.setTimeout = function(code, delay) {
 };
 
 // Prevent setInterval from breaking out to SpiderMonkey
-Narcissus.interpreter.narcissusGlobalBase.setInterval = function(code, delay) {
+Narcissus.interpreter.globalBase.setInterval = function(code, delay) {
     var timeoutCode = (typeof code === "string") ?
             function() { Narcissus.interpreter.evaluate(code); } :
             code;
@@ -60,6 +60,6 @@ Narcissus.interpreter.narcissusGlobalBase.setInterval = function(code, delay) {
 };
 
 // Hack to avoid problems with the Image constructor in Narcissus.
-Narcissus.interpreter.narcissusGlobalBase.Image = function() {};
+Narcissus.interpreter.globalBase.Image = function() {};
 
 

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -285,8 +285,7 @@ Narcissus.interpreter = (function() {
     function getValue(v) {
         if (v instanceof Reference) {
             if (!v.base) {
-                if (hostGlobal[v.propertyName]) return hostGlobal[v.propertyName];
-                else throw new ReferenceError(v.propertyName + " is not defined",
+                throw new ReferenceError(v.propertyName + " is not defined",
                                          v.node.filename, v.node.lineno);
             }
             return v.base[v.propertyName];

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -180,7 +180,7 @@ Narcissus.interpreter = (function() {
         // Hide Narcissus implementation code.
         if (name === "Narcissus")
             return false;
-        if (hostGlobal.hasOwnProperty(name))
+        if (name in hostGlobal)
             return true;
         return Narcissus.definitions.noPropFound(name);
     };

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -273,7 +273,8 @@ Narcissus.interpreter = (function() {
     function getValue(v) {
         if (v instanceof Reference) {
             if (!v.base) {
-                throw new ReferenceError(v.propertyName + " is not defined",
+                if (hostGlobal[v.propertyName]) return hostGlobal[v.propertyName];
+                else throw new ReferenceError(v.propertyName + " is not defined",
                                          v.node.filename, v.node.lineno);
             }
             return v.base[v.propertyName];

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -75,7 +75,7 @@ Narcissus.interpreter = (function() {
     }
 
     // The underlying global object for narcissus.
-    var narcissusGlobal = {
+    var narcissusGlobalBase = {
         // Value properties.
         NaN: NaN, Infinity: Infinity, undefined: undefined,
 
@@ -158,6 +158,18 @@ Narcissus.interpreter = (function() {
         version: function() { return Narcissus.options.version; },
         quit: function() { throw END; }
     };
+
+    var narcissusGlobal = {};
+    function resetEnvironment() {
+        ExecutionContext.current = new ExecutionContext(GLOBAL_CODE);
+        for (let i in narcissusGlobal) {
+            delete narcissusGlobal[i];
+        }
+        for (let i in narcissusGlobalBase) {
+            narcissusGlobal[i] = narcissusGlobalBase[i];
+        }
+    }
+    resetEnvironment();
 
     // Create global handler with needed modifications.
     var globalHandler = definitions.makePassthruHandler(narcissusGlobal);
@@ -1192,7 +1204,11 @@ Narcissus.interpreter = (function() {
     }
 
     return {
+        // resetEnvironment wipes any properties added externally to global,
+        // but properties added to narcisssusGlobalBase will persist.
         global: global,
+        narcissusGlobalBase: narcissusGlobalBase,
+        resetEnvironment: resetEnvironment,
         evaluate: evaluate,
         repl: repl,
         test: test

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -162,11 +162,11 @@ Narcissus.interpreter = (function() {
     var narcissusGlobal = {};
     function resetEnvironment() {
         ExecutionContext.current = new ExecutionContext(GLOBAL_CODE);
-        for (let i in narcissusGlobal) {
-            delete narcissusGlobal[i];
+        for (let key in narcissusGlobal) {
+            delete narcissusGlobal[key];
         }
-        for (let i in globalBase) {
-            narcissusGlobal[i] = globalBase[i];
+        for (let key in globalBase) {
+            narcissusGlobal[key] = globalBase[key];
         }
     }
     resetEnvironment();

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -75,7 +75,7 @@ Narcissus.interpreter = (function() {
     }
 
     // The underlying global object for narcissus.
-    var narcissusGlobalBase = {
+    var globalBase = {
         // Value properties.
         NaN: NaN, Infinity: Infinity, undefined: undefined,
 
@@ -165,8 +165,8 @@ Narcissus.interpreter = (function() {
         for (let i in narcissusGlobal) {
             delete narcissusGlobal[i];
         }
-        for (let i in narcissusGlobalBase) {
-            narcissusGlobal[i] = narcissusGlobalBase[i];
+        for (let i in globalBase) {
+            narcissusGlobal[i] = globalBase[i];
         }
     }
     resetEnvironment();
@@ -1204,9 +1204,9 @@ Narcissus.interpreter = (function() {
 
     return {
         // resetEnvironment wipes any properties added externally to global,
-        // but properties added to narcisssusGlobalBase will persist.
+        // but properties added to globalBase will persist.
         global: global,
-        narcissusGlobalBase: narcissusGlobalBase,
+        globalBase: globalBase,
         resetEnvironment: resetEnvironment,
         evaluate: evaluate,
         repl: repl,


### PR DESCRIPTION
Two changes in this push.  First, modifying 'has' method of the globalHandler to correctly search for missing properties.  Second, adding a resetEnvironment function, which resets the narcissusGlobal object.
