### PR TITLE
package.json for npm + minor bugfix

### DIFF
--- a/lib/jsdecomp.js
+++ b/lib/jsdecomp.js
@@ -464,7 +464,7 @@ Narcissus.decompiler = (function() {
                     var tc = t.children;
                     var l;
                     // see if the left needs to be a string
-                    if (/[^A-Za-z0-9_$]/.test(tc[0].value)) {
+                    if (tc[0].value === "" || /[^A-Za-z0-9_$]/.test(tc[0].value)) {
                         l = nodeStr(tc[0]);
                     } else {
                         l = pp(tc[0], d);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narcissus",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "author": "Mozilla",
   "directories": {"lib": "./lib"}
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "narcissus",
+  "version": "0.1.0",
+  "author": "Mozilla",
+  "directories": {"lib": "./lib"}
+}


### PR DESCRIPTION
I am using narcissus in one of my node.js projects (https://github.com/Sage/streamlinejs) and I would like to be able to install my package with NPM (node package manager). For this I need an NPM installer for narcissus.

So I created a package.json file for narcissus. I have set the version number to 0.1.0 because I could not find one. It should probably be changed. I did not set any "engine" dependency because narcisssus does not have direct dependencies on node.

To complete the process, narcissus need to be "published" to NPM. I could do it but I would probably need to be authorized by Mozilla to do so. So it is probably better if it gets published directly by Mozilla. The steps are simple and described on https://github.com/isaacs/npm/blob/master/doc/developers.md#readme 

I also fixed a really minor bug in the decompiler. It was generating invalid code for empty property names in object initializer: var foo = { "": "hello" }; --> var foo = { : "hello" }; The fix was trivial.

Note: I just completed the process to obtain the committer's agreement. My request has not been approved yet but the bug report is here: https://bugzilla.mozilla.org/show_bug.cgi?id=631785

And BTW, kudos to all involved for creating this great component. 

Bruno
