### PR TITLE
Adjustments for .start and .end node properties

### DIFF
--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -648,6 +648,7 @@ Narcissus.parser = (function() {
             if (t.peekOnSameLine() === IDENTIFIER) {
                 t.get();
                 n.label = t.token.value;
+                n.end = t.token.end;
             }
 
             n.target = n.label
@@ -1693,8 +1694,9 @@ Narcissus.parser = (function() {
                         }
                     }
                 } while (t.match(COMMA));
-                n.end = t.mustMatch(RIGHT_CURLY).end;
+                t.mustMatch(RIGHT_CURLY);
             }
+            n.end = t.token.end;
             break;
 
           case LEFT_PAREN:

--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -747,8 +747,8 @@ Narcissus.parser = (function() {
                     label = t.token.value;
                     if (x.allLabels.has(label))
                         throw t.newSyntaxError("Duplicate label");
-                    t.get();
                     n = new Node(t, { type: LABEL, label: label });
+                    t.get();
                     n.statement = Statement(t, x.pushLabel(label).nest());
                     n.target = (n.statement.type === LABEL) ? n.statement.target : n.statement;
                     return n;

--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -1051,10 +1051,14 @@ Narcissus.parser = (function() {
           case LEFT_PAREN:
             tt = LET;
             s = letBlock;
+            t.get(); // skip paren
             break;
         }
 
         n = new Node(t, { type: tt, destructurings: [] });
+        if (tt == LET) {
+            t.unget(); // restore paren
+        }
 
         do {
             tt = t.get();

--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -211,9 +211,9 @@ Narcissus.parser = (function() {
     Np.push = function (kid) {
         // kid can be null e.g. [1, , 2].
         if (kid !== null) {
-            if (kid.start < this.start)
+            if (this.start === undefined || kid.start < this.start)
                 this.start = kid.start;
-            if (this.end < kid.end)
+            if (this.end === undefined || this.end < kid.end)
                 this.end = kid.end;
         }
         return this.children.push(kid);
@@ -323,7 +323,7 @@ Narcissus.parser = (function() {
         t.mustMatch(LEFT_CURLY);
         var n = new Node(t, blockInit());
         Statements(t, x.update({ parentBlock: n }).pushTarget(n), n);
-        t.mustMatch(RIGHT_CURLY);
+        n.end = t.mustMatch(RIGHT_CURLY).end;
         return n;
     }
 
@@ -494,7 +494,7 @@ Narcissus.parser = (function() {
           case LEFT_CURLY:
             n = new Node(t, blockInit());
             Statements(t, x.update({ parentBlock: n }).pushTarget(n).nest(), n);
-            t.mustMatch(RIGHT_CURLY);
+            n.end = t.mustMatch(RIGHT_CURLY).end;
             return n;
 
           case IF:
@@ -1298,12 +1298,12 @@ Narcissus.parser = (function() {
         if (t.match(YIELD, true))
             return ReturnOrYield(t, x);
 
-        n = new Node(t, { type: ASSIGN });
         lhs = ConditionalExpression(t, x);
 
         if (!t.match(ASSIGN)) {
             return lhs;
         }
+        n = new Node(t, { type: ASSIGN });
 
         switch (lhs.type) {
           case OBJECT_INIT:
@@ -1562,7 +1562,7 @@ Narcissus.parser = (function() {
                 n2 = new Node(t, { type: INDEX });
                 n2.push(n);
                 n2.push(Expression(t, x));
-                t.mustMatch(RIGHT_BRACKET);
+                n2.end = t.mustMatch(RIGHT_BRACKET).end;
                 break;
 
               case LEFT_PAREN:
@@ -1589,8 +1589,10 @@ Narcissus.parser = (function() {
         var n, n2;
 
         n = new Node(t, { type: LIST });
-        if (t.match(RIGHT_PAREN, true))
+        if (t.match(RIGHT_PAREN, true)) {
+            n.end = t.token.end;
             return n;
+        }
         do {
             n2 = AssignExpression(t, x);
             if (n2.type === YIELD && !n2.parenthesized && t.peek() === COMMA)
@@ -1602,7 +1604,7 @@ Narcissus.parser = (function() {
             }
             n.push(n2);
         } while (t.match(COMMA));
-        t.mustMatch(RIGHT_PAREN);
+        n.end = t.mustMatch(RIGHT_PAREN).end;
 
         return n;
     }
@@ -1636,7 +1638,7 @@ Narcissus.parser = (function() {
                                    tail: ComprehensionTail(t, x) });
                 n = n2;
             }
-            t.mustMatch(RIGHT_BRACKET);
+            n.end = t.mustMatch(RIGHT_BRACKET).end;
             break;
 
           case LEFT_CURLY:
@@ -1682,13 +1684,15 @@ Narcissus.parser = (function() {
                         }
                     }
                 } while (t.match(COMMA));
-                t.mustMatch(RIGHT_CURLY);
+                n.end = t.mustMatch(RIGHT_CURLY).end;
             }
             break;
 
           case LEFT_PAREN:
+            var start = t.token.start;
             n = ParenExpression(t, x);
-            t.mustMatch(RIGHT_PAREN);
+            n.start = start;
+            n.end = t.mustMatch(RIGHT_PAREN).end;
             n.parenthesized = true;
             break;
 

--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -533,8 +533,12 @@ Narcissus.parser = (function() {
                 while ((tt=t.peek(true)) !== CASE && tt !== DEFAULT &&
                         tt !== RIGHT_CURLY)
                     n2.statements.push(Statement(t, x2));
+                n2.statements.start = (n2.statements.children.length === 0 ?
+                                       n2.statements.start + 1 :
+                                       n2.statements.children[0].start);
                 n.cases.push(n2);
             }
+            n.end = t.token.end;
             return n;
 
           case FOR:
@@ -995,7 +999,7 @@ Narcissus.parser = (function() {
         }
 
         if (tt === LEFT_CURLY)
-            t.mustMatch(RIGHT_CURLY);
+            f.body.end = t.mustMatch(RIGHT_CURLY).end;
 
         f.end = t.token.end;
         f.functionForm = functionForm;

--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -1236,6 +1236,7 @@ Narcissus.parser = (function() {
             t.mustMatch(IN);
             n.object = Expression(t, x);
             MaybeRightParen(t, p);
+            n.end = t.token.end;
             body.push(n);
         } while (t.match(FOR));
 
@@ -1243,6 +1244,7 @@ Narcissus.parser = (function() {
         if (t.match(IF))
             body.guard = HeadExpression(t, x);
 
+        body.end = t.token.end;
         return body;
     }
 

--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -756,8 +756,9 @@ Narcissus.parser = (function() {
             n = new Node(t, { type: SEMICOLON });
             t.unget();
             n.expression = Expression(t, x);
-            n.end = n.expression.end;
-            break;
+            MagicalSemicolon(t);
+            n.end = (t.token.type === SEMICOLON ? t.token.end : n.expression.end);
+            return n;
         }
 
         MagicalSemicolon(t);


### PR DESCRIPTION
This branch contains a number of parser adjustments to node .start and .end properties, such that they more accurately match the text segments of respective nodes (and encloses descendant nodes). I intend to keep fixing more of these in this branch.

I've used this to build a source transforming tool, which will soon be up on github.
