### PR TITLE
Narcissus did not accept keywords as property names

### DIFF
--- a/lib/jsdecomp.js
+++ b/lib/jsdecomp.js
@@ -467,7 +467,7 @@ Narcissus.decompiler = (function() {
                     var tc = t.children;
                     var l;
                     // see if the left needs to be a string
-                    if (tc[0].value === "" || /[^A-Za-z0-9_$]/.test(tc[0].value)) {
+                    if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(tc[0].value)) {
                         l = nodeStr(tc[0]);
                     } else {
                         l = pp(tc[0], d);

--- a/lib/jslex.js
+++ b/lib/jslex.js
@@ -107,6 +107,19 @@ Narcissus.lexer = (function() {
             }
             return this.token;
         },
+        
+        forceIdentifier: function() {
+        	if (!this.match(IDENTIFIER)) {
+        		// keywords are valid property names in ES 5
+        		if (this.get() >= definitions.keywords[0] || this.unget) {
+        			this.token.type = IDENTIFIER;
+        		}
+        		else {
+        			throw this.newSyntaxError("Missing identifier");
+        		}
+        	}
+        	return this.token;
+        },
 
         peek: function (scanOperand) {
             var tt, next;

--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -1238,7 +1238,7 @@ Narcissus.parser = (function() {
               case DOT:
                 n2 = new Node(t);
                 n2.push(n);
-                t.mustMatch(IDENTIFIER);
+                t.forceIdentifier();
                 n2.push(new Node(t));
                 break;
 


### PR DESCRIPTION
Narcissus only accepted identifiers as property names. From the ES5 specs, it seems that keywords are also allowed (IdentifierName vs. Identifier).

Bruno
