### PR TITLE
Less harmonious "module" keyword

### DIFF
--- a/lib/jslex.js
+++ b/lib/jslex.js
@@ -54,6 +54,12 @@ Narcissus.lexer = (function() {
     // Set constants in the local scope.
     eval(definitions.consts);
 
+    // Banned keywords by language version
+    const blackLists = { 185: {}, harmony: {} };
+    blackLists[185][IMPORT] = true;
+    blackLists[185][EXPORT] = true;
+    blackLists[185][MODULE] = true;
+
     // Build up a trie of operator tokens.
     var opTokens = {};
     for (var op in definitions.opTypeNames) {
@@ -83,6 +89,7 @@ Narcissus.lexer = (function() {
         this.unexpectedEOF = false;
         this.filename = f || "";
         this.lineno = l || 1;
+        this.blackList = blackLists[Narcissus.options.version];
     }
 
     Tokenizer.prototype = {
@@ -374,6 +381,10 @@ Narcissus.lexer = (function() {
 
             var id = input.substring(token.start, this.cursor);
             token.type = definitions.keywords[id] || IDENTIFIER;
+            if (token.type in this.blackList) {
+                // banned keyword, this is an identifier
+                token.type = IDENTIFIER;
+            }
             token.value = id;
         },
 

--- a/lib/jslex.js
+++ b/lib/jslex.js
@@ -56,8 +56,6 @@ Narcissus.lexer = (function() {
 
     // Banned keywords by language version
     const blackLists = { 185: {}, harmony: {} };
-    blackLists[185][IMPORT] = true;
-    blackLists[185][EXPORT] = true;
     blackLists[185][MODULE] = true;
 
     // Build up a trie of operator tokens.


### PR DESCRIPTION
I'm using Narcissus to parse out-there-in-the-horrible-wild-web JavaScript code. Unfortunately, the addition of "module" as a keyword (for Harmony) has broken my parsing of some things from Google, as they use "module" as an identifier. Although the module /statement/ is blacklisted in the parser, it's still interpreted as a keyword in the lexer, so it just fails to parse.

I've added a similar blacklist to the lexer module, which causes the listed keywords to be treated as identifiers. The only keyword listed is MODULE of course (since the other two which are blacklisted statements, import and export, are future-use keywords by the ECMAScript spec), but that was sufficient for me to parse more Googcode.

Having this in a separate blacklist in a separate module is probably far from ideal. If you have another suggestion for how to organize it, I'll change it and send another pull request.
