### PR TITLE
Support for non-Unix (read: non-sense) newlines.

### DIFF
--- a/lib/jslex.js
+++ b/lib/jslex.js
@@ -167,8 +167,14 @@ Narcissus.lexer = (function() {
                     this.cursor++;
                     for (;;) {
                         ch = input[this.cursor++];
+                        next = input[this.cursor];
                         if (ch === undefined)
                             return;
+
+                        if (ch === '\r') {
+                            // check for \r\n
+                            if (next !== '\n') ch = '\n';
+                        }
 
                         if (ch === '\n') {
                             this.lineno++;

--- a/lib/jslex.js
+++ b/lib/jslex.js
@@ -437,7 +437,9 @@ Narcissus.lexer = (function() {
                 this.lexZeroNumber(ch);
             } else if (ch === '"' || ch === "'") {
                 this.lexString(ch);
-            } else if (this.scanNewlines && ch === '\n') {
+            } else if (this.scanNewlines && (ch === '\n' || ch === '\r')) {
+                // if this was a \r, look for \r\n
+                if (ch === '\r' && input[this.cursor] === '\n') this.cursor++;
                 token.type = NEWLINE;
                 token.value = '\n';
                 this.lineno++;

--- a/lib/jslex.js
+++ b/lib/jslex.js
@@ -135,6 +135,15 @@ Narcissus.lexer = (function() {
             for (;;) {
                 var ch = input[this.cursor++];
                 var next = input[this.cursor];
+                // handle \r, \r\n and (always preferable) \n
+                if (ch === '\r') {
+                    // if the next character is \n, we don't care about this at all
+                    if (next === '\n') continue;
+
+                    // otherwise, we want to consider this as a newline
+                    ch = '\n';
+                }
+
                 if (ch === '\n' && !this.scanNewlines) {
                     this.lineno++;
                 } else if (ch === '/' && next === '*') {


### PR DESCRIPTION
I was surprised to find that Narcissus doesn't support \r or \r\n newlines. This patch adds support, and even intelligently counts newlines such that both Mac<10 newlines (\r) and DOS newlines (\r\n) count as one line break.

As per all of my patches, feel free to consider a less hackish way to do this :)
