### PR TITLE
Support for all forms of whitespace in ECMA-262 7.2

### DIFF
--- a/lib/jsdefs.js
+++ b/lib/jsdefs.js
@@ -129,6 +129,23 @@ Narcissus.definitions = (function() {
         "while", "with",
     ];
 
+    // Whitespace characters (see ECMA-262 7.2)
+    var whitespaceChars = [
+        // normal whitespace:
+        "\u0009", "\u000B", "\u000C", "\u0020", "\u00A0", "\uFEFF", 
+
+        // high-Unicode whitespace:
+        "\u1680", "\u180E",
+        "\u2000", "\u2001", "\u2002", "\u2003", "\u2004", "\u2005", "\u2006",
+        "\u2007", "\u2008", "\u2009", "\u200A",
+        "\u202F", "\u205F", "\u3000"
+    ];
+
+    var whitespace = {};
+    for (var i = 0; i < whitespaceChars.length; i++) {
+        whitespace[whitespaceChars[i]] = true;
+    }
+
     // Operator and punctuator mapping from token to tree node type name.
     // NB: because the lexer doesn't backtrack, all token prefixes must themselves
     // be valid tokens (e.g. !== is acceptable because its prefixes are the valid
@@ -633,6 +650,7 @@ Narcissus.definitions = (function() {
 
     return {
         tokens: tokens,
+        whitespace: whitespace,
         opTypeNames: opTypeNames,
         keywords: keywords,
         isStatementStartCode: isStatementStartCode,

--- a/lib/jslex.js
+++ b/lib/jslex.js
@@ -166,7 +166,7 @@ Narcissus.lexer = (function() {
                             break;
                         }
                     }
-                } else if (ch !== ' ' && ch !== '\t') {
+                } else if (!(ch in definitions.whitespace)) {
                     this.cursor--;
                     return;
                 }


### PR DESCRIPTION
Just like it says in the topic. Although I needed BOM in particular, support for the Ogham space mark will greatly improve compatibility with ancient Irish esotericist JavaScript programmers.
