### PR TITLE
Support for continues nested in switches nested in loops.

### DIFF
--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -93,6 +93,7 @@ Narcissus.parser = (function() {
         this.allLabels = new Stack();
         this.currentLabels = new Stack();
         this.labeledTargets = new Stack();
+        this.defaultLoopTarget = null;
         this.defaultTarget = null;
         this.blackList = blackLists[Narcissus.options.version];
         Narcissus.options.ecma3OnlyMode && (this.ecma3OnlyMode = true);
@@ -120,12 +121,13 @@ Narcissus.parser = (function() {
                                  allLabels: this.allLabels.push(label) });
         },
         pushTarget: function(target) {
-            var isDefaultTarget = target.isLoop || target.type === SWITCH;
+            var isDefaultLoopTarget = target.isLoop;
+            var isDefaultTarget = isDefaultLoopTarget || target.type === SWITCH;
 
             if (this.currentLabels.isEmpty()) {
-                return isDefaultTarget
-                     ? this.update({ defaultTarget: target })
-                     : this;
+                if (isDefaultLoopTarget) this.update({ defaultLoopTarget: target });
+                if (isDefaultTarget) this.update({ defaultTarget: target });
+                return this;
             }
 
             target.labels = new StringMap();
@@ -134,6 +136,9 @@ Narcissus.parser = (function() {
             });
             return this.update({ currentLabels: new Stack(),
                                  labeledTargets: this.labeledTargets.push(target),
+                                 defaultLoopTarget: isDefaultLoopTarget
+                                                    ? target
+                                                    : this.defaultLoopTarget,
                                  defaultTarget: isDefaultTarget
                                                 ? target
                                                 : this.defaultTarget });
@@ -646,9 +651,13 @@ Narcissus.parser = (function() {
                 n.label = t.token.value;
             }
 
-            n.target = n.label
-                     ? x2.labeledTargets.find(function(target) { return target.labels.has(n.label) })
-                     : x2.defaultTarget;
+            if (n.label) {
+                n.target = x2.labeledTargets.find(function(target) { return target.labels.has(n.label) });
+            } else if (tt === CONTINUE) {
+                n.target = x2.defaultLoopTarget;
+            } else {
+                n.target = x2.defaultTarget;
+            }
 
             if (!n.target)
                 throw t.newSyntaxError("Invalid " + ((tt === BREAK) ? "break" : "continue"));


### PR DESCRIPTION
Just like the topic says. Had to add an extra property to StaticContext (defaultLoopTarget) to distinguish targets for both break and continue from targets that only continue can accept.
