### PR TITLE
Fixed the handling of return [no LineTerminator here] semicolon insertion

### DIFF
--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -795,7 +795,7 @@ Narcissus.parser = (function() {
         }
         n = new Node(t, { value: undefined });
 
-        tt2 = t.peek(true);
+        tt2 = (tt === RETURN) ? t.peekOnSameLine(true) : t.peek(true);
         if (tt2 !== END && tt2 !== NEWLINE &&
             tt2 !== SEMICOLON && tt2 !== RIGHT_CURLY
             && (tt !== YIELD ||


### PR DESCRIPTION
Semicolon insertion was broken for return. I'm pretty sure it's still broken for throw, but I'm not sure how to fix that (and I haven't seen any test cases).
