### PR TITLE
Support for unicode identifiers

### DIFF
--- a/lib/jslex.js
+++ b/lib/jslex.js
@@ -361,14 +361,16 @@ Narcissus.lexer = (function() {
         },
 
         // FIXME: Unicode escape sequences
-        // FIXME: Unicode identifiers
         lexIdent: function (ch) {
             var token = this.token, input = this.source;
 
+            /* check for ASCII sequences, and only use expensive
+             * isValidIdentifierChar for non-ASCII */
             do {
                 ch = input[this.cursor++];
             } while ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
-                     (ch >= '0' && ch <= '9') || ch === '$' || ch === '_');
+                     (ch >= '0' && ch <= '9') || ch === '$' || ch === '_' ||
+                     (ch >= '\u007F' && isValidIdentifierChar(ch, false)));
 
             this.cursor--;  // Put the non-word character back.
 
@@ -408,7 +410,8 @@ Narcissus.lexer = (function() {
             token.lineno = this.lineno;
 
             var ch = input[this.cursor++];
-            if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch === '$' || ch === '_') {
+            if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch === '$' || ch === '_' ||
+                (ch >= '\u007F' && isValidIdentifierChar(ch, true))) {
                 this.lexIdent(ch);
             } else if (scanOperand && ch === '/') {
                 this.lexRegExp(ch);
@@ -453,6 +456,24 @@ Narcissus.lexer = (function() {
             return e;
         },
     };
+
+    /* is this a valid identifier character? Since JS doesn't expose a
+     * convenient way to determine if a a character is in a particular Unicode
+     * category, we use metacircularity to accomplish this (oh yeaaaah!). If ch
+     * isn't guaranteed to be one character, this can be VERY unsafe */
+    function isValidIdentifierChar(ch, first) {
+        // create an object to test this in
+        var x = {};
+        x["x"+ch] = true;
+        x[ch] = true;
+
+        // then try
+        try {
+            return (eval("(x." + (first?"":"x") + ch + ")") ? true : false);
+        } catch (ex) {
+            return false;
+        }
+    }
 
     return { Tokenizer: Tokenizer };
 

--- a/lib/jslex.js
+++ b/lib/jslex.js
@@ -489,6 +489,7 @@ Narcissus.lexer = (function() {
          * metacircularity to accomplish this (oh yeaaaah!) */
         getValidIdentifierChar: function(first) {
             var input = this.source;
+            if (this.cursor >= input.length) return null;
             var ch = input[this.cursor];
 
             // first check for \u escapes
@@ -522,7 +523,7 @@ Narcissus.lexer = (function() {
             // then use eval to determine if it's a valid character
             var valid = false;
             try {
-                valid = (eval("(x." + (first?"":"x") + ch + ")") === true);
+                valid = (Function("x", "return (x." + (first?"":"x") + ch + ");")(x) === true);
             } catch (ex) {}
             if (valid) this.cursor++;
             return (valid ? ch : null);

--- a/lib/jslex.js
+++ b/lib/jslex.js
@@ -362,19 +362,13 @@ Narcissus.lexer = (function() {
 
         // FIXME: Unicode escape sequences
         lexIdent: function (ch) {
-            var token = this.token, input = this.source;
+            var token = this.token;
+            var id = ch;
 
-            /* check for ASCII sequences, and only use expensive
-             * isValidIdentifierChar for non-ASCII */
-            do {
-                ch = input[this.cursor++];
-            } while ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
-                     (ch >= '0' && ch <= '9') || ch === '$' || ch === '_' ||
-                     (ch >= '\u007F' && isValidIdentifierChar(ch, false)));
+            while ((ch = this.getValidIdentifierChar(false)) !== null) {
+                id += ch;
+            }
 
-            this.cursor--;  // Put the non-word character back.
-
-            var id = input.substring(token.start, this.cursor);
             token.type = definitions.keywords[id] || IDENTIFIER;
             token.value = id;
         },
@@ -409,10 +403,10 @@ Narcissus.lexer = (function() {
             token.start = this.cursor;
             token.lineno = this.lineno;
 
-            var ch = input[this.cursor++];
-            if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch === '$' || ch === '_' ||
-                (ch >= '\u007F' && isValidIdentifierChar(ch, true))) {
-                this.lexIdent(ch);
+            var ich = this.getValidIdentifierChar(true);
+            var ch = (ich === null) ? input[this.cursor++] : null;
+            if (ich !== null) {
+                this.lexIdent(ich);
             } else if (scanOperand && ch === '/') {
                 this.lexRegExp(ch);
             } else if (ch in opTokens) {
@@ -455,25 +449,54 @@ Narcissus.lexer = (function() {
                        : this.cursor;
             return e;
         },
+
+        /* Gets a single valid identifier char from the input stream, or null
+         * if there is none.
+         * Since JavaScript provides no convenient way to determine if a
+         * character is in a particular Unicode category, we use
+         * metacircularity to accomplish this (oh yeaaaah!) */
+        getValidIdentifierChar: function(first) {
+            var input = this.source;
+            var ch = input[this.cursor];
+
+            // first check for \u escapes
+            if (ch === '\\' && input[this.cursor+1] === 'u') {
+                // get the character value
+                try {
+                    ch = String.fromCharCode(parseInt(
+                        input.substring(this.cursor + 2, this.cursor + 6),
+                        16));
+                } catch (ex) {
+                    return null;
+                }
+                this.cursor += 5;
+            }
+
+            // check directly for ASCII
+            if (ch <= "\u007F") {
+                if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch === '$' || ch === '_' ||
+                    (!first && (ch >= '0' && ch <= '9'))) {
+                    this.cursor++;
+                    return ch;
+                }
+                return null;
+            }
+    
+            // create an object to test this in
+            var x = {};
+            x["x"+ch] = true;
+            x[ch] = true;
+    
+            // then use eval to determine if it's a valid character
+            var valid = false;
+            try {
+                valid = (eval("(x." + (first?"":"x") + ch + ")") === true);
+            } catch (ex) {}
+            if (valid) this.cursor++;
+            return (valid ? ch : null);
+        },
     };
 
-    /* is this a valid identifier character? Since JS doesn't expose a
-     * convenient way to determine if a a character is in a particular Unicode
-     * category, we use metacircularity to accomplish this (oh yeaaaah!). If ch
-     * isn't guaranteed to be one character, this can be VERY unsafe */
-    function isValidIdentifierChar(ch, first) {
-        // create an object to test this in
-        var x = {};
-        x["x"+ch] = true;
-        x[ch] = true;
-
-        // then try
-        try {
-            return (eval("(x." + (first?"":"x") + ch + ")") ? true : false);
-        } catch (ex) {
-            return false;
-        }
-    }
 
     return { Tokenizer: Tokenizer };
 


### PR DESCRIPTION
I've added support for identifiers with Unicode characters. Right now I test this with the following crazy metacircular function:

```
function isValidIdentifierChar(ch, first) {
    // create an object to test this in
    var x = {};
    x["x"+ch] = true;
    x[ch] = true;

    // then try
    try {
        return (eval("(x." + (first?"":"x") + ch + ")") ? true : false);
    } catch (ex) {
        return false;
    }
}
```

This is enormously unsafe if ch is more than one codepoint, but harmless if it isn't. I had to do it this way because JavaScript doesn't provide (as far as I could tell?) a way of determining the Unicode category of a given codepoint, so I just have to trust the host parser to know that.

This function is only called for high-Unicode (>ASCII) codepoints.
