### PR TITLE
Bugfix for 'if' statements immediately followed by regex literals.

### DIFF
--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -502,7 +502,7 @@ Narcissus.parser = (function() {
             n.condition = HeadExpression(t, x);
             x2 = x.pushTarget(n).nest();
             n.thenPart = Statement(t, x2);
-            n.elsePart = t.match(ELSE) ? Statement(t, x2) : null;
+            n.elsePart = t.match(ELSE, true) ? Statement(t, x2) : null;
             return n;
 
           case SWITCH:


### PR DESCRIPTION
Since a / immediately after an if block is the beginning of a regex terminal, and not a division operator (since you can't have a division operator immediately after a statement with no numerator), the t.match(ELSE) which checks if the if is followed by an else needs to set scanOperand to true, to scan for regex instead of division.
