### PR TITLE
Support for in expressions in the condition and increment of a for loop.

### DIFF
--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -550,7 +550,7 @@ Narcissus.parser = (function() {
             x2 = x.pushTarget(n).nest();
             x3 = x.update({ inForLoopInit: true });
             n2 = null;
-            if ((tt = t.peek()) !== SEMICOLON) {
+            if ((tt = t.peek(true)) !== SEMICOLON) {
                 if (tt === VAR || tt === CONST) {
                     t.get();
                     n2 = Variables(t, x3);
@@ -600,11 +600,11 @@ Narcissus.parser = (function() {
                 t.mustMatch(SEMICOLON);
                 if (n.isEach)
                     throw t.newSyntaxError("Invalid for each..in loop");
-                n.condition = (t.peek() === SEMICOLON)
+                n.condition = (t.peek(true) === SEMICOLON)
                               ? null
                               : Expression(t, x3);
                 t.mustMatch(SEMICOLON);
-                tt2 = t.peek();
+                tt2 = t.peek(true);
                 n.update = (x.parenFreeMode
                             ? tt2 === LEFT_CURLY || definitions.isStatementStartCode[tt2]
                             : tt2 === RIGHT_PAREN)

--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -549,6 +549,7 @@ Narcissus.parser = (function() {
                 t.mustMatch(LEFT_PAREN);
             x2 = x.pushTarget(n).nest();
             x3 = x.update({ inForLoopInit: true });
+            n2 = null;
             if ((tt = t.peek()) !== SEMICOLON) {
                 if (tt === VAR || tt === CONST) {
                     t.get();
@@ -594,6 +595,7 @@ Narcissus.parser = (function() {
                     n.iterator = n2;
                 }
             } else {
+                x3.inForLoopInit = false;
                 n.setup = n2;
                 t.mustMatch(SEMICOLON);
                 if (n.isEach)


### PR DESCRIPTION
inForLoopInit was not being set to false after getting the initializer of a for loop, so in-expressions were not allowed in the other parts of the loop header.
