### PR TITLE
Fix for scanning line comments while also scanning for newlines for semicolon insertion

### DIFF
--- a/lib/jslex.js
+++ b/lib/jslex.js
@@ -162,7 +162,11 @@ Narcissus.lexer = (function() {
                             return;
 
                         if (ch === '\n') {
-                            this.lineno++;
+                            if (this.scanNewlines) {
+                                this.cursor--;
+                            } else {
+                                this.lineno++;
+                            }
                             break;
                         }
                     }


### PR DESCRIPTION
e.g.

```
if (foo) return // lol comment
someFunction();
```

Previously would evaluate the same as

```
if (foo) return someFunction();
```

which is just all wrong :)
