### PR TITLE
fix infinite loop when parsing "if('"

### DIFF
--- a/lib/jslex.js
+++ b/lib/jslex.js
@@ -300,6 +300,8 @@ Narcissus.lexer = (function() {
 
             var hasEscapes = false;
             var delim = ch;
+            if (input.length <= this.cursor)
+                throw this.newSyntaxError("Unterminated string literal");
             while ((ch = input[this.cursor++]) !== delim) {
                 if (this.cursor == input.length)
                     throw this.newSyntaxError("Unterminated string literal");


### PR DESCRIPTION
The narcissus parser gets into an infinite loop then parsing  "if('". This can easily be verified by running this:

``` javascript
require("./lib/parser").parse("if('")
```

This patch fixes this bug.
