### PR TITLE
Fix for escaping particularly-weird strings

### DIFF
--- a/lib/jsdecomp.js
+++ b/lib/jsdecomp.js
@@ -75,13 +75,33 @@ Narcissus.decompiler = (function() {
         return isBlock(n) && n.children.length > 0;
     }
 
+    function nodeStrEscape(str) {
+        return str.replace(/\\/g, "\\\\")
+                  .replace(/"/g, "\\\"")
+                  .replace(/\n/g, "\\n")
+                  .replace(/\r/g, "\\r")
+                  .replace(/</g, "\\u003C")
+                  .replace(/>/g, "\\u003E");
+    }
+
     function nodeStr(n) {
-        return '"' +
-               n.value.replace(/\\/g, "\\\\")
-                      .replace(/"/g, "\\\"")
-                      .replace(/\n/g, "\\n")
-                      .replace(/\r/g, "\\r") +
-               '"';
+        if (/[\u0000-\u001F]/.test(n.value)) {
+            // use the convoluted algorithm to avoid broken low characters
+            var str = "";
+            for (var i = 0; i < n.value.length; i++) {
+                var c = n.value[i];
+                if (c <= "\x1F") {
+                    var cc = c.charCodeAt(0).toString(16);
+                    if (cc.length === 1) cc = "0" + cc;
+                    str += "\\u00" + cc;
+                } else {
+                    str += nodeStrEscape(c);
+                }
+            }
+            return '"' + str + '"';
+        }
+
+        return '"' + nodeStrEscape(n.value) + '"';
     }
 
     function pp(n, d, inLetHead) {

--- a/lib/jsdecomp.js
+++ b/lib/jsdecomp.js
@@ -85,15 +85,15 @@ Narcissus.decompiler = (function() {
     }
 
     function nodeStr(n) {
-        if (/[\u0000-\u001F]/.test(n.value)) {
-            // use the convoluted algorithm to avoid broken low characters
+        if (/[\u0000-\u001F\u0080-\uFFFF]/.test(n.value)) {
+            // use the convoluted algorithm to avoid broken low/high characters
             var str = "";
             for (var i = 0; i < n.value.length; i++) {
                 var c = n.value[i];
-                if (c <= "\x1F") {
+                if (c <= "\x1F" || c >= "\x80") {
                     var cc = c.charCodeAt(0).toString(16);
-                    if (cc.length === 1) cc = "0" + cc;
-                    str += "\\u00" + cc;
+                    while (cc.length < 4) cc = "0" + cc;
+                    str += "\\u" + cc;
                 } else {
                     str += nodeStrEscape(c);
                 }


### PR DESCRIPTION
Since Narcissus doesn't store the original sequence of bytes that generated a string literal, only the resultant string, some strings can't be properly decompiled.

This patch makes escaping strings more robust to weird characters, namely < and > (in case of JS embedded in HTML) and below-ASCII chars. You can test its behavior with a script such as:

var str = "\0";

With the current Narcissus, that will output a script with a literal null byte in it, which is bound to eff up just about everything. With this patch, it outputs

var str = "\u0000";

Which isn't quite identical, but is better :).

It also includes a change to escape < and >. These aren't strictly necessary, but they help a lot with scripts embedded in HTML (with HTML embedded in strings)
