### PR TITLE
Object literal property keywords

### DIFF
--- a/lib/jsdecomp.js
+++ b/lib/jsdecomp.js
@@ -467,7 +467,8 @@ Narcissus.decompiler = (function() {
                     var tc = t.children;
                     var l;
                     // see if the left needs to be a string
-                    if (tc[0].value === "" || /[^A-Za-z0-9_$]/.test(tc[0].value)) {
+                    if (tc[0].value === "" || /[^A-Za-z0-9_$]/.test(tc[0].value) ||
+                        (/^[a-z]*$/.test(tc[0].value) && tc[0].value in Narcissus.definitions.keywords)) {
                         l = nodeStr(tc[0]);
                     } else {
                         l = pp(tc[0], d);


### PR DESCRIPTION
Fix for string output of object literals for JS parsers that don't like object literal properties to be keywords. e.g. there exist parsers out there that will barf on

{delete: "yee haw"}

and require

{"delete": "yee haw"}

instead.
