### PR TITLE
Changes needed for Zaphod

### DIFF
--- a/lib/jsdefs.js
+++ b/lib/jsdefs.js
@@ -54,7 +54,9 @@
 
     var narcissus = {
         options: {
-            version: 185
+            version: 185,
+            // Global variables to hide from the interpreter
+            hiddenHostGlobals: { Narcissus: true }
         },
         hostSupportsEvalConst: (function() {
             try {
@@ -468,9 +470,6 @@ Narcissus.definitions = (function() {
         };
     }
 
-    // default function used when looking for a property in the global object
-    function noPropFound() { return undefined; }
-
     var hasOwnProperty = ({}).hasOwnProperty;
 
     function hasOwn(obj, name) {
@@ -674,7 +673,6 @@ Narcissus.definitions = (function() {
         whitelistHandler: whitelistHandler,
         blacklistHandler: blacklistHandler,
         makePassthruHandler: makePassthruHandler,
-        noPropFound: noPropFound,
         StringMap: StringMap,
         ObjectMap: ObjectMap,
         Stack: Stack

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -211,7 +211,8 @@ Narcissus.interpreter = (function() {
             });
     }
 
-    var hostHandler = definitions.blacklistHandler(hostGlobal, { Narcissus: true });
+    var hostHandler = definitions.blacklistHandler(hostGlobal,
+            Narcissus.options.hiddenHostGlobals);
     var hostHandlerGet = hostHandler.get;
     hostHandler.get = function(receiver, name) {
         return wrapNative(name, hostHandlerGet(receiver, name));
@@ -320,6 +321,10 @@ Narcissus.interpreter = (function() {
     function getValue(v) {
         if (v instanceof Reference) {
             if (!v.base) {
+                // Hook needed for Zaphod
+                if (Narcissus.interpreter.getValueHook) {
+                    return Narcissus.interpreter.getValueHook(v.propertyName);
+                }
                 throw new ReferenceError(v.propertyName + " is not defined",
                                          v.node.filename, v.node.lineno);
             }

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -212,7 +212,7 @@ Narcissus.interpreter = (function() {
     }
 
     var hostHandler = definitions.blacklistHandler(hostGlobal,
-            Narcissus.options.hiddenHostGlobals);
+        Narcissus.options.hiddenHostGlobals);
     var hostHandlerGet = hostHandler.get;
     hostHandler.get = function(receiver, name) {
         return wrapNative(name, hostHandlerGet(receiver, name));
@@ -322,9 +322,8 @@ Narcissus.interpreter = (function() {
         if (v instanceof Reference) {
             if (!v.base) {
                 // Hook needed for Zaphod
-                if (Narcissus.interpreter.getValueHook) {
+                if (Narcissus.interpreter.getValueHook)
                     return Narcissus.interpreter.getValueHook(v.propertyName);
-                }
                 throw new ReferenceError(v.propertyName + " is not defined",
                                          v.node.filename, v.node.lineno);
             }
@@ -1482,6 +1481,7 @@ Narcissus.interpreter = (function() {
         globalBase: globalBase,
         resetEnvironment: resetEnvironment,
         evaluate: evaluate,
+        getValueHook: null,
         repl: repl,
         test: test
     };


### PR DESCRIPTION
Replacing (broken) noPropFound hook with getValueHook and making globals hidden from the interpreter a configurable property
