### PR TITLE
Exceptions

### DIFF
--- a/lib/jsdefs.js
+++ b/lib/jsdefs.js
@@ -278,6 +278,36 @@ Narcissus.definitions = (function() {
         return ((typeof fn) === "function") && fn.toString().match(/\[native code\]/);
     }
 
+    var Fpapply = Function.prototype.apply;
+
+    function apply(f, o, a) {
+        return Fpapply.call(f, [o].concat(a));
+    }
+
+    function applyNew(f, a) {
+        switch (a.length) {
+          case 0:
+            return new f();
+          case 1:
+            return new f(a[0]);
+          case 2:
+            return new f(a[0], a[1]);
+          case 3:
+            return new f(a[0], a[1], a[2]);
+          default:
+            var argStr = "a[0]";
+            for (var i = 1, n = a.length; i < n; i++)
+                argStr += ",a[" + i + "]";
+            return eval("new f(" + argStr + ")");
+        }
+    }
+
+    if (Function.prototype.bind) {
+        applyNew = function applyNew(f, a) {
+            return new (f.bind.apply(f, [,].concat(a)))();
+        };
+    }
+
     function getPropertyDescriptor(obj, name) {
         while (obj) {
             if (({}).hasOwnProperty.call(obj, name))
@@ -682,6 +712,8 @@ Narcissus.definitions = (function() {
         defineMemoGetter: defineMemoGetter,
         defineProperty: defineProperty,
         isNativeCode: isNativeCode,
+        apply: apply,
+        applyNew: applyNew,
         mirrorHandler: mirrorHandler,
         mixinHandler: mixinHandler,
         whitelistHandler: whitelistHandler,

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -1437,7 +1437,6 @@ Narcissus.interpreter = (function() {
                     printStackTrace(e.stack);
             } catch (e) {
                 print("uncaught exception: " + string(e));
-                throw e;
             }
         }
         ExecutionContext.current = null;

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -70,6 +70,8 @@ Narcissus.interpreter = (function() {
     const StaticEnv = resolver.StaticEnv;
     const Def = resolver.Def;
 
+    const applyNew = definitions.applyNew;
+
     const GLOBAL_CODE = 0, EVAL_CODE = 1, FUNCTION_CODE = 2, MODULE_CODE = 3;
 
     // An unexported type of exception object used for internal signalling.
@@ -1275,22 +1277,7 @@ Narcissus.interpreter = (function() {
         definitions.defineProperty(Fp, "__construct__",
                                    function (a, x) {
                                        a = Array.prototype.splice.call(a, 0, a.length);
-                                       switch (a.length) {
-                                         case 0:
-                                           return new this();
-                                         case 1:
-                                           return new this(a[0]);
-                                         case 2:
-                                           return new this(a[0], a[1]);
-                                         case 3:
-                                           return new this(a[0], a[1], a[2]);
-                                         default:
-                                           var argStr = "";
-                                           for (var i=0; i<a.length; i++) {
-                                               argStr += 'a[' + i + '],';
-                                           }
-                                           return eval('new this(' + argStr.slice(0,-1) + ');');
-                                       }
+                                       return applyNew(this, a);
                                    }, true, true, true);
 
         // Since we use native functions such as Date along with host ones such

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -72,6 +72,19 @@ Narcissus.interpreter = (function() {
 
     const GLOBAL_CODE = 0, EVAL_CODE = 1, FUNCTION_CODE = 2, MODULE_CODE = 3;
 
+    // An unexported type of exception object used for internal signalling.
+    // User exceptions are self-representing; whenever we use exceptions to
+    // model other kinds of control flow, such as early exits from loops or
+    // functions, we use instances of InternalSignal.
+    function InternalSignal() { }
+
+    InternalSignal.prototype = { toString: function() { return "[object InternalSignal]" } };
+
+    const RETURN_SIGNAL = new InternalSignal,
+          BREAK_SIGNAL = new InternalSignal,
+          CONTINUE_SIGNAL = new InternalSignal,
+          EXIT_SIGNAL = new InternalSignal;
+
     function ExecutionContext(type, version) {
         this.type = type;
         this.version = version;
@@ -104,24 +117,13 @@ Narcissus.interpreter = (function() {
             x2.caller = x.caller;
             x2.callee = x.callee;
             x2.scope = x.version === "harmony" ? { object: new Object, parent: x.scope } : x.scope;
-            try {
-                var ast = parser.parse(s);
-                if (x.version === "harmony") {
-                    resolver.resolve(ast, new StaticEnv(x.staticEnv));
-                    instantiateModules(ast, x2.scope);
-                }
-                x2.execute(ast);
-                return x2.result;
-            } catch (e if e instanceof SyntaxError || isStackOverflow(e)) {
-                /*
-                 * If we get an internal error during parsing we need to reify
-                 * the exception as a Narcissus THROW.
-                 *
-                 * See bug 152646.
-                 */
-                x.result = e;
-                throw THROW;
+            var ast = parser.parse(s);
+            if (x.version === "harmony") {
+                resolver.resolve(ast, new StaticEnv(x.staticEnv));
+                instantiateModules(ast, x2.scope);
             }
+            x2.execute(ast);
+            return x2.result;
         },
 
         // Class constructors.  Where ECMA-262 requires C.length === 1, we declare
@@ -175,14 +177,9 @@ Narcissus.interpreter = (function() {
             evaluate(snarf(s), s, 1)
         },
         version: function() { return ExecutionContext.current.version; },
-        quit: function() { throw END; },
+        quit: function() { throw EXIT_SIGNAL; },
         assertEq: function() {
-            try {
-                return assertEq.apply(null, arguments);
-            } catch (e) {
-                ExecutionContext.current.result = e;
-                throw THROW;
-            }
+            return assertEq.apply(null, arguments);
         }
     };
 
@@ -297,14 +294,6 @@ Narcissus.interpreter = (function() {
             ExecutionContext.current = this;
             try {
                 execute(n, this);
-            } catch (e if e === THROW) {
-                // Propagate the throw to the previous context if it exists.
-                if (prev) {
-                    prev.result = this.result;
-                    throw THROW;
-                }
-                // Otherwise reflect the throw into host JS.
-                throw this.result;
             } finally {
                 ExecutionContext.current = prev;
             }
@@ -551,7 +540,7 @@ Narcissus.interpreter = (function() {
                         if (t.statements.children.length) {
                             try {
                                 execute(t.statements, x);
-                            } catch (e if e === BREAK && x.target === n) {
+                            } catch (e if e === BREAK_SIGNAL && x.target === n) {
                                 break switch_loop;
                             }
                         }
@@ -571,9 +560,9 @@ Narcissus.interpreter = (function() {
             while (!n.condition || getValue(execute(n.condition, x))) {
                 try {
                     execute(n.body, x);
-                } catch (e if e === BREAK && x.target === n) {
+                } catch (e if e === BREAK_SIGNAL && x.target === n) {
                     break;
-                } catch (e if e === CONTINUE && x.target === n) {
+                } catch (e if e === CONTINUE_SIGNAL && x.target === n) {
                     // Must run the update expression.
                 }
                 n.update && getValue(execute(n.update, x));
@@ -599,9 +588,9 @@ Narcissus.interpreter = (function() {
                 putValue(execute(r, x), a[i], r);
                 try {
                     execute(n.body, x);
-                } catch (e if e === BREAK && x.target === n) {
+                } catch (e if e === BREAK_SIGNAL && x.target === n) {
                     break;
-                } catch (e if e === CONTINUE && x.target === n) {
+                } catch (e if e === CONTINUE_SIGNAL && x.target === n) {
                     continue;
                 }
             }
@@ -611,30 +600,31 @@ Narcissus.interpreter = (function() {
             do {
                 try {
                     execute(n.body, x);
-                } catch (e if e === BREAK && x.target === n) {
+                } catch (e if e === BREAK_SIGNAL && x.target === n) {
                     break;
-                } catch (e if e === CONTINUE && x.target === n) {
+                } catch (e if e === CONTINUE_SIGNAL && x.target === n) {
                     continue;
                 }
             } while (getValue(execute(n.condition, x)));
             break;
 
           case BREAK:
+            x.target = n.target;
+            throw BREAK_SIGNAL;
+
           case CONTINUE:
             x.target = n.target;
-            throw n.type;
+            throw CONTINUE_SIGNAL;
 
           case TRY:
             try {
                 execute(n.tryBlock, x);
-            } catch (e if e === THROW && (j = n.catchClauses.length)) {
+            } catch (e if !(e instanceof InternalSignal) && (j = n.catchClauses.length)) {
                 e = x.result;
                 x.result = undefined;
                 for (i = 0; ; i++) {
-                    if (i === j) {
-                        x.result = e;
-                        throw THROW;
-                    }
+                    if (i === j)
+                        throw e;
                     t = n.catchClauses[i];
                     x.scope = {object: {}, parent: x.scope};
                     definitions.defineProperty(x.scope.object, t.varName, e, true);
@@ -654,13 +644,12 @@ Narcissus.interpreter = (function() {
             break;
 
           case THROW:
-            x.result = getValue(execute(n.exception, x));
-            throw THROW;
+            throw getValue(execute(n.exception, x));
 
           case RETURN:
             // Check for returns with no return value
             x.result = n.value ? getValue(execute(n.value, x)) : undefined;
-            throw RETURN;
+            throw RETURN_SIGNAL;
 
           case WITH:
             r = execute(n.object, x);
@@ -704,7 +693,7 @@ Narcissus.interpreter = (function() {
           case LABEL:
             try {
                 execute(n.statement, x);
-            } catch (e if e === BREAK && x.target === n.target) {
+            } catch (e if e === BREAK_SIGNAL && x.target === n.target) {
             }
             break;
 
@@ -1185,7 +1174,7 @@ Narcissus.interpreter = (function() {
 
             try {
                 x2.execute(f.body);
-            } catch (e if e === RETURN) {
+            } catch (e if e === RETURN_SIGNAL) {
                 return x2.result;
             }
             return undefined;
@@ -1358,6 +1347,9 @@ Narcissus.interpreter = (function() {
         }
     }
 
+    // Used to interpret the .break directive at the REPL.
+    const CANCEL_SIGNAL = new InternalSignal;
+
     // A read-eval-print-loop that roughly tracks the behavior of the js shell.
     function repl() {
 
@@ -1390,8 +1382,6 @@ Narcissus.interpreter = (function() {
             }
         }
 
-        const BREAK_INTERACTION = {};
-
         // isCommand :: (string) -> boolean
         function isCommand(line) {
             switch (line.trim()) {
@@ -1409,10 +1399,10 @@ Narcissus.interpreter = (function() {
                 // FALL THROUGH
 
               case ".break":
-                throw BREAK_INTERACTION;
+                throw CANCEL_SIGNAL;
 
               case ".exit":
-                throw END;
+                throw EXIT_SIGNAL;
             }
             return false;
         }
@@ -1445,11 +1435,9 @@ Narcissus.interpreter = (function() {
                 }
                 execute(ast, x);
                 display(x.result);
-            } catch (e if e === THROW) {
-                print("uncaught exception: " + string(x.result));
-            } catch (e if e === END) {
+            } catch (e if e === EXIT_SIGNAL) {
                 break;
-            } catch (e if e === BREAK_INTERACTION) {
+            } catch (e if e === CANCEL_SIGNAL) {
                 continue;
             } catch (e if e instanceof SyntaxError) {
                 const PREFIX = (e.filename || "stdin") + ":" + e.lineNumber + ": ";
@@ -1461,7 +1449,7 @@ Narcissus.interpreter = (function() {
                 if (e.stack)
                     printStackTrace(e.stack);
             } catch (e) {
-                print("unexpected Narcissus exception (" + e + ")");
+                print("uncaught exception: " + string(e));
                 throw e;
             }
         }

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -622,7 +622,6 @@ Narcissus.interpreter = (function() {
             try {
                 execute(n.tryBlock, x);
             } catch (e if !(e instanceof InternalSignal) && (j = n.catchClauses.length)) {
-                e = x.result;
                 x.result = undefined;
                 for (i = 0; ; i++) {
                     if (i === j)


### PR DESCRIPTION
Resolves bug 583436 by representing thrown exceptions directly, and throwing special unique objects (that are kept private to the internals of the interpreter) to represent non-local control flow like break, continue, and return.

```
https://bugzilla.mozilla.org/show_bug.cgi?id=583436
```

Dave
