### PR TITLE
fix abstraction leak of function internals

### DIFF
--- a/lib/jsdesugar.js
+++ b/lib/jsdesugar.js
@@ -84,6 +84,8 @@ Narcissus.desugaring = (function() {
     var definitions = Narcissus.definitions;
     var parser = Narcissus.parser;
 
+    const Dict = definitions.Dict;
+
     eval(definitions.consts);
 
     function id(node, name, readOnly) {
@@ -219,13 +221,13 @@ Narcissus.desugaring = (function() {
                 })],
                 funDecls: [],
                 varDecls: [],
-                modDefns: new definitions.StringMap(),
-                modAssns: new definitions.StringMap(),
-                modDecls: new definitions.StringMap(),
-                modLoads: new definitions.StringMap(),
+                modDefns: new Dict(),
+                modAssns: new Dict(),
+                modDecls: new Dict(),
+                modLoads: new Dict(),
                 impDecls: [],
                 expDecls: [],
-                exports: new definitions.StringMap(),
+                exports: new Dict(),
                 hasEmptyReturn: false,
                 hasReturnWithValue: true,
                 isGenerator: false
@@ -351,7 +353,7 @@ Narcissus.desugaring = (function() {
                 children: [body],
                 varDecls: [],
                 // FIXME: this is probably wrong if body has label
-                labels: new definitions.StringMap()
+                labels: new Dict()
             });
         }
         body.children.unshift(stmt);
@@ -472,13 +474,13 @@ Narcissus.desugaring = (function() {
                                 type: NOT,
                                 value: "!",
                                 children: [caught],
-                                labels: new definitions.StringMap()
+                                labels: new Dict()
                             }),
                             thenPart: catchNode.block,
                             elsePart: null
                         })],
                         varDecls: [],
-                        labels: new definitions.StringMap()
+                        labels: new Dict()
                     }),
                     blockComments: []
                 });
@@ -516,7 +518,7 @@ Narcissus.desugaring = (function() {
                                 type: NOT,
                                 value: "!",
                                 children: [caught],
-                                labels: new definitions.StringMap()
+                                labels: new Dict()
                             }), catchNode.guard]
                         }),
                         thenPart: catchNode.synth({
@@ -535,12 +537,12 @@ Narcissus.desugaring = (function() {
                                 })
                             }), catchNode.block],
                             varDecls: [],
-                            labels: new definitions.StringMap()
+                            labels: new Dict()
                         }),
                         elsePart: null
                     })],
                     varDecls: [],
-                    labels: new definitions.StringMap()
+                    labels: new Dict()
                 }),
                 blockComments: []
             });
@@ -577,7 +579,7 @@ Narcissus.desugaring = (function() {
                     type: NOT,
                     value: "!",
                     children: [caught],
-                    labels: new definitions.StringMap()
+                    labels: new Dict()
                 }),
                 thenPart: guard.synth({
                     type: THROW,
@@ -599,7 +601,7 @@ Narcissus.desugaring = (function() {
                 value: "{",
                 children: stmts,
                 varDecls: [initCaught],
-                labels: new definitions.StringMap()
+                labels: new Dict()
             })
         }));
     }
@@ -732,13 +734,13 @@ Narcissus.desugaring = (function() {
                 children: stmts,
                 funDecls: [],
                 varDecls: decl ? [decl] : [],
-                modDefns: new definitions.StringMap(),
-                modAssns: new definitions.StringMap(),
-                modDecls: new definitions.StringMap(),
-                modLoads: new definitions.StringMap(),
+                modDefns: new Dict(),
+                modAssns: new Dict(),
+                modDecls: new Dict(),
+                modLoads: new Dict(),
                 impDecls: [],
                 expDecls: [],
-                exports: new definitions.StringMap(),
+                exports: new Dict(),
                 hasEmptyReturn: false,
                 hasReturnWithValue: !genexp,
                 isGenerator: genexp

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -177,6 +177,14 @@ Narcissus.interpreter = (function() {
 
             evaluate(snarf(s), s, 1)
         },
+        dis: function dis(f) {
+            if (typeof f !== "function")
+                throw new TypeError(f + " is not a function");
+            var fint = functionInternals.get(f);
+            if (!fint)
+                throw new TypeError("only works on scripts");
+            return fint.getBytecode().toString();
+        },
         version: function() { return ExecutionContext.current.version; },
         quit: function() { throw EXIT_SIGNAL; },
         assertEq: function() {
@@ -452,6 +460,13 @@ Narcissus.interpreter = (function() {
                 }
             }
             break;
+
+          case GENERATOR:
+            f = functionInternals.get(x.callee);
+            u = new Narcissus.bytecode.Generator(f.getBytecode(), x);
+            x.thisGenerator = u;
+            x.result = u.userObject;
+            throw RETURN_SIGNAL;
 
           case SCRIPT:
             t = x.scope.object;
@@ -812,10 +827,13 @@ Narcissus.interpreter = (function() {
             c = n.children;
             t = getValue(execute(c[0], x));
             u = getValue(execute(c[1], x));
-            if (isObject(u) && typeof u.__hasInstance__ === "function")
-                v = u.__hasInstance__(t);
+            if (isObject(u) && functionInternals.has(u))
+                v = hasInstance(u, t);
+            // Since we use native functions such as Date along with host ones such
+            // as global.eval, we want both to be considered instances of the native
+            // Function constructor.
             else
-                v = t instanceof u;
+                v = (t instanceof u) || (u === Function && t instanceof global.Function);
             break;
 
           case LSH:
@@ -934,13 +952,13 @@ Narcissus.interpreter = (function() {
             a = execute(c[1], x);
             f = getValue(r);
             x.staticEnv = n.staticEnv;
-            if (isPrimitive(f) || typeof f.__call__ !== "function") {
+            if (typeof f !== "function") {
                 throw new TypeError(r + " is not callable", c[0].filename, c[0].lineno);
             }
             t = (r instanceof Reference) ? r.base : null;
             if (t instanceof Activation)
                 t = null;
-            v = f.__call__(t, a, x);
+            v = call(f, t, a, x);
             break;
 
           case NEW:
@@ -954,10 +972,10 @@ Narcissus.interpreter = (function() {
             } else {
                 a = execute(c[1], x);
             }
-            if (isPrimitive(f) || typeof f.__construct__ !== "function") {
+            if (typeof f !== "function") {
                 throw new TypeError(r + " is not a constructor", c[0].filename, c[0].lineno);
             }
-            v = f.__construct__(a, x);
+            v = construct(f, a, x);
             break;
 
           case ARRAY_INIT:
@@ -1038,22 +1056,12 @@ Narcissus.interpreter = (function() {
     // pollute the scope of heavyweight functions.  Also delete its 'constructor'
     // property so that it doesn't pollute function scopes.
 
-    Activation.prototype.__proto__ = null;
-    delete Activation.prototype.constructor;
+    Activation.prototype = Object.create(null);
 
-    function FunctionObject(node, scope) {
+    function FunctionInternals(node, scope) {
         this.node = node;
         this.scope = scope;
-        definitions.defineProperty(this, "length", node.params.length, true, true, true);
-        var proto = {};
-        definitions.defineProperty(this, "prototype", proto, true);
-        definitions.defineProperty(proto, "constructor", this, false, false, true);
-    }
-
-    function GeneratorFunctionObject(node, scope) {
-        FunctionObject.call(this, node, scope);
-        if (!node.proc)
-            node.proc = Narcissus.bytecode.compile(node);
+        this.length = node.params.length;
     }
 
     /*
@@ -1161,170 +1169,102 @@ Narcissus.interpreter = (function() {
 
     // Returns a new function wrapped with a Proxy.
     function newFunction(n, x) {
-        var fobj = n.isGenerator
-                 ? new GeneratorFunctionObject(n, x.scope)
-                 : new FunctionObject(n, x.scope);
-        var handler = definitions.makePassthruHandler(fobj);
+        var fint = new FunctionInternals(n, x.scope);
+        var props = Object.create(Fp);
+        definitions.defineProperty(props, "length", fint.length, false, false, true);
+        definitions.defineProperty(props, "toString", function() {
+            return fint.toString();
+        }, false, false, true);
+        var handler = definitions.makePassthruHandler(props);
         var p = Proxy.createFunction(handler,
-                                     function() { return fobj.__call__(this, arguments, x); },
-                                     function() { return fobj.__construct__(arguments, x); });
+                                     function() { return fint.call(p, this, arguments, x); },
+                                     function() { return fint.construct(p, arguments, x); });
+        functionInternals.set(p, fint);
+        var proto = {};
+        definitions.defineProperty(p, "prototype", proto, true);
+        definitions.defineProperty(proto, "constructor", p, false, false, true);
         return p;
     }
 
-    var FOp = FunctionObject.prototype = {
+    const functionInternals = new WeakMap();
 
-        // Internal methods.
-        __call__: function (t, a, x) {
+    function hasInstance(u, v) {
+        if (isPrimitive(v))
+            return false;
+        var p = u.prototype;
+        if (isPrimitive(p)) {
+            throw new TypeError("'prototype' property is not an object",
+                                this.node.filename, this.node.lineno);
+        }
+        var o;
+        while ((o = Object.getPrototypeOf(v))) {
+            if (o === p)
+                return true;
+            v = o;
+        }
+        return false;
+    }
+
+    function call(f, t, a, x) {
+        var fint = functionInternals.get(f);
+        if (!fint)
+            return f.apply(t, a);
+        return fint.call(f, t, a, x);
+    }
+
+    function construct(f, a, x) {
+        var fint = functionInternals.get(f);
+        if (!fint)
+            return applyNew(f, a);
+        return fint.construct(f, a, x);
+    }
+
+    var FIp = FunctionInternals.prototype = {
+        call: function(f, t, a, x) {
             var x2 = new ExecutionContext(FUNCTION_CODE, x.version);
             x2.thisObject = t || global;
             x2.thisModule = null;
             x2.caller = x;
-            x2.callee = this;
-            definitions.defineProperty(a, "callee", this, false, false, true);
-            var f = this.node;
-            x2.scope = {object: new Activation(f, a), parent: this.scope};
-
+            x2.callee = f;
+            definitions.defineProperty(a, "callee", f, false, false, true);
+            var n = this.node;
+            x2.scope = {object: new Activation(n, a), parent: this.scope};
             try {
-                x2.execute(f.body);
+                x2.execute(n.body);
             } catch (e if e === RETURN_SIGNAL) {
                 return x2.result;
             }
             return undefined;
         },
 
-        __construct__: function (a, x) {
-            var o = new Object;
+        construct: function(f, a, x) {
             var p = this.prototype;
-            if (isObject(p))
-                o.__proto__ = p;
-            // else o.__proto__ defaulted to Object.prototype
+            var o = isObject(p) ? Object.create(p) : new Object;
 
-            var v = this.__call__(o, a, x);
+            var v = this.call(f, o, a, x);
             if (isObject(v))
                 return v;
             return o;
         },
 
-        __hasInstance__: function (v) {
-            if (isPrimitive(v))
-                return false;
-            var p = this.prototype;
-            if (isPrimitive(p)) {
-                throw new TypeError("'prototype' property is not an object",
-                                    this.node.filename, this.node.lineno);
-            }
-            var o;
-            while ((o = v.__proto__)) {
-                if (o === p)
-                    return true;
-                v = o;
-            }
-            return false;
+        getBytecode: function() {
+            var n = this.node;
+            if (!n.proc)
+                n.proc = Narcissus.bytecode.compile(n.body.type === GENERATOR ? n.body : n);
+            return n.proc;
         },
 
-        // Standard methods.
-        toString: function () {
+        toString: function() {
             return this.node.getSource();
-        },
-
-        apply: function (t, a) {
-            // Curse ECMA again!
-            if (typeof this.__call__ !== "function") {
-                throw new TypeError("Function.prototype.apply called on" +
-                                    " uncallable object");
-            }
-
-            if (t === undefined || t === null)
-                t = global;
-            else if (typeof t !== "object")
-                t = toObject(t, t);
-
-            if (a === undefined || a === null) {
-                a = {};
-                definitions.defineProperty(a, "length", 0, false, false, true);
-            } else if (a instanceof Array) {
-                var v = {};
-                for (var i = 0, j = a.length; i < j; i++)
-                    definitions.defineProperty(v, i, a[i], false, false, true);
-                definitions.defineProperty(v, "length", i, false, false, true);
-                a = v;
-            } else if (!(a instanceof Object)) {
-                // XXX check for a non-arguments object
-                throw new TypeError("Second argument to Function.prototype.apply" +
-                                    " must be an array or arguments object",
-                                    this.node.filename, this.node.lineno);
-            }
-
-            return this.__call__(t, a, ExecutionContext.current);
-        },
-
-        call: function (t) {
-            // Curse ECMA a third time!
-            var a = Array.prototype.splice.call(arguments, 1);
-            return this.apply(t, a);
         }
     };
 
     // Connect Function.prototype and Function.prototype.constructor in global.
-    reflectClass('Function', FOp);
-
-    var GFOp = GeneratorFunctionObject.prototype = Object.create(FOp, {
-        getBytecode: {
-            value: function() {
-                return this.node.proc.toString();
-            },
-            enumerable: false,
-            configurable: true,
-            writable: true
-        }
-    });
-
-    GFOp.__call__ = function(t, a, x) {
-        var x2 = new ExecutionContext(FUNCTION_CODE, x.version);
-        x2.thisObject = t || global;
-        x2.thisModule = null;
-        x2.caller = x;
-        x2.callee = this;
-        var f = this.node;
-        x2.scope = {object: new Activation(f, a), parent: this.scope};
-        var g = new Narcissus.bytecode.Generator(f.proc, x2);
-        x2.thisGenerator = g;
-        return g.userObject;
-    };
-
-    // Help native and host-scripted functions be like FunctionObjects.
-    var Fp = Function.prototype;
-    var REp = RegExp.prototype;
-
-    if (!('__call__' in Fp)) {
-        definitions.defineProperty(Fp, "__call__",
-                                   function (t, a, x) {
-                                       // Curse ECMA yet again!
-                                       a = Array.prototype.splice.call(a, 0, a.length);
-                                       return this.apply(t, a);
-                                   }, true, true, true);
-        definitions.defineProperty(REp, "__call__",
-                                   function (t, a, x) {
-                                       a = Array.prototype.splice.call(a, 0, a.length);
-                                       return this.exec.apply(this, a);
-                                   }, true, true, true);
-        definitions.defineProperty(Fp, "__construct__",
-                                   function (a, x) {
-                                       a = Array.prototype.splice.call(a, 0, a.length);
-                                       return applyNew(this, a);
-                                   }, true, true, true);
-
-        // Since we use native functions such as Date along with host ones such
-        // as global.eval, we want both to be considered instances of the native
-        // Function constructor.
-        definitions.defineProperty(Fp, "__hasInstance__",
-                                   function (v) {
-                                       return v instanceof Function || v instanceof global.Function;
-                                   }, true, true, true);
-    }
+    var Fp = new Function;
+    reflectClass('Function', Fp);
 
     function thunk(f, x) {
-        return function () { return f.__call__(this, arguments, x); };
+        return function () { return functionInternals.get(f).call(f, this, arguments, x); };
     }
 
     function resolveGlobal(ast) {

--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -1112,7 +1112,8 @@ Narcissus.parser = (function() {
         if (Narcissus.options.version === "harmony" && !f.isExplicitGenerator && f.body.hasYield)
             throw t.newSyntaxError("yield in non-generator function");
 
-        f.isGenerator = f.isExplicitGenerator || f.body.hasYield;
+        if (f.isExplicitGenerator || f.body.hasYield)
+            f.body = new Node(t, { type: GENERATOR, body: f.body });
 
         return f;
     }


### PR DESCRIPTION
The function proxies totally hide their internals but the old implementation strategy leaked the details with **call** and **construct** methods. This patch hides them in a WeakMap so that Narcissus functions are now completely opaque.
