### PR TITLE
Making interpreter work in nodejs

### DIFF
--- a/lib/interpreter.js
+++ b/lib/interpreter.js
@@ -41,8 +41,7 @@
  *
  * ***** END LICENSE BLOCK ***** */
 
-exports.definitions = require("./lib/definitions");
-exports.lexer = require("./lib/lexer");
-exports.parser = require("./lib/parser");
-exports.decompiler = require("./lib/decompiler");
-exports.interpreter = require("./lib/interpreter");
+require("./jsexec");
+
+for (var exp in Narcissus.interpreter)
+    exports[exp] = Narcissus.interpreter[exp];

--- a/lib/interpreter.js
+++ b/lib/interpreter.js
@@ -41,8 +41,8 @@
  *
  * ***** END LICENSE BLOCK ***** */
 
-exports.definitions = require("./lib/definitions");
-exports.lexer = require("./lib/lexer");
-exports.parser = require("./lib/parser");
-exports.decompiler = require("./lib/decompiler");
-exports.interpreter = require("./lib/interpreter");
+require("./jsresolve");
+require("./jsexec");
+
+for (var exp in Narcissus.interpreter)
+    exports[exp] = Narcissus.interpreter[exp];

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -55,6 +55,9 @@
  */
 
 Narcissus.interpreter = (function() {
+    if (typeof Proxy === 'undefined' && typeof require === 'function') {
+        var Proxy = require('node-proxy');
+    }
 
     var parser = Narcissus.parser;
     var definitions = Narcissus.definitions;
@@ -93,15 +96,19 @@ Narcissus.interpreter = (function() {
             try {
                 x2.execute(parser.parse(s));
                 return x2.result;
-            } catch (e if e instanceof SyntaxError || isStackOverflow(e)) {
-                /*
-                 * If we get an internal error during parsing we need to reify
-                 * the exception as a Narcissus THROW.
-                 *
-                 * See bug 152646.
-                 */
-                x.result = e;
-                throw THROW;
+            } catch (e) {
+                    if (e instanceof SyntaxError || isStackOverflow(e)) {
+                    /*
+                     * If we get an internal error during parsing we need to reify
+                     * the exception as a Narcissus THROW.
+                     *
+                     * See bug 152646.
+                     */
+                    x.result = e;
+                    throw THROW;
+                } else {
+                    throw e;
+                }
             }
         },
 
@@ -162,10 +169,10 @@ Narcissus.interpreter = (function() {
     var narcissusGlobal = {};
     function resetEnvironment() {
         ExecutionContext.current = new ExecutionContext(GLOBAL_CODE);
-        for (let key in narcissusGlobal) {
+        for (var key in narcissusGlobal) {
             delete narcissusGlobal[key];
         }
-        for (let key in globalBase) {
+        for (var key in globalBase) {
             narcissusGlobal[key] = globalBase[key];
         }
     }
@@ -260,14 +267,18 @@ Narcissus.interpreter = (function() {
             ExecutionContext.current = this;
             try {
                 execute(n, this);
-            } catch (e if e === THROW) {
-                // Propagate the throw to the previous context if it exists.
-                if (prev) {
-                    prev.result = this.result;
-                    throw THROW;
+            } catch (e) {
+                if (e === THROW) {
+                    // Propagate the throw to the previous context if it exists.
+                    if (prev) {
+                        prev.result = this.result;
+                        throw THROW;
+                    }
+                    // Otherwise reflect the throw into host JS.
+                    throw this.result;
+                } else {
+                    throw e;
                 }
-                // Otherwise reflect the throw into host JS.
-                throw this.result;
             } finally {
                 ExecutionContext.current = prev;
             }
@@ -417,8 +428,12 @@ Narcissus.interpreter = (function() {
                         if (t.statements.children.length) {
                             try {
                                 execute(t.statements, x);
-                            } catch (e if e === BREAK && x.target === n) {
-                                break switch_loop;
+                            } catch (e) {
+                                if (e === BREAK && x.target === n) {
+                                    break switch_loop;
+                                } else {
+                                    throw e;
+                                }
                             }
                         }
                         if (++i === j)
@@ -437,10 +452,14 @@ Narcissus.interpreter = (function() {
             while (!n.condition || getValue(execute(n.condition, x))) {
                 try {
                     execute(n.body, x);
-                } catch (e if e === BREAK && x.target === n) {
-                    break;
-                } catch (e if e === CONTINUE && x.target === n) {
-                    // Must run the update expression.
+                } catch (e) { 
+                    if (e === BREAK && x.target === n) {
+                        break;
+                    } else if (e === CONTINUE && x.target === n) {
+                        // Must run the update expression.
+                    } else {
+                        throw e;
+                    }
                 }
                 n.update && getValue(execute(n.update, x));
             }
@@ -465,10 +484,14 @@ Narcissus.interpreter = (function() {
                 putValue(execute(r, x), a[i], r);
                 try {
                     execute(n.body, x);
-                } catch (e if e === BREAK && x.target === n) {
-                    break;
-                } catch (e if e === CONTINUE && x.target === n) {
-                    continue;
+                } catch (e) {
+                    if (e === BREAK && x.target === n) {
+                        break;
+                    } else if (e === CONTINUE && x.target === n) {
+                        continue;
+                    } else {
+                        throw e;
+                    }
                 }
             }
             break;
@@ -477,10 +500,14 @@ Narcissus.interpreter = (function() {
             do {
                 try {
                     execute(n.body, x);
-                } catch (e if e === BREAK && x.target === n) {
-                    break;
-                } catch (e if e === CONTINUE && x.target === n) {
-                    continue;
+                } catch (e) {
+                    if (e === BREAK && x.target === n) {
+                        break;
+                    } else if (e === CONTINUE && x.target === n) {
+                        continue;
+                    } else {
+                        throw e;
+                    }
                 }
             } while (getValue(execute(n.condition, x)));
             break;
@@ -493,25 +520,29 @@ Narcissus.interpreter = (function() {
           case TRY:
             try {
                 execute(n.tryBlock, x);
-            } catch (e if e === THROW && (j = n.catchClauses.length)) {
-                e = x.result;
-                x.result = undefined;
-                for (i = 0; ; i++) {
-                    if (i === j) {
-                        x.result = e;
-                        throw THROW;
+            } catch (e) {
+                if (e === THROW && (j = n.catchClauses.length)) {
+                    e = x.result;
+                    x.result = undefined;
+                    for (i = 0; ; i++) {
+                        if (i === j) {
+                            x.result = e;
+                            throw THROW;
+                        }
+                        t = n.catchClauses[i];
+                        x.scope = {object: {}, parent: x.scope};
+                        definitions.defineProperty(x.scope.object, t.varName, e, true);
+                        try {
+                            if (t.guard && !getValue(execute(t.guard, x)))
+                                continue;
+                            execute(t.block, x);
+                            break;
+                        } finally {
+                            x.scope = x.scope.parent;
+                        }
                     }
-                    t = n.catchClauses[i];
-                    x.scope = {object: {}, parent: x.scope};
-                    definitions.defineProperty(x.scope.object, t.varName, e, true);
-                    try {
-                        if (t.guard && !getValue(execute(t.guard, x)))
-                            continue;
-                        execute(t.block, x);
-                        break;
-                    } finally {
-                        x.scope = x.scope.parent;
-                    }
+                } else {
+                    throw e;
                 }
             } finally {
                 if (n.finallyBlock)
@@ -570,7 +601,10 @@ Narcissus.interpreter = (function() {
           case LABEL:
             try {
                 execute(n.statement, x);
-            } catch (e if e === BREAK && x.target === n.target) {
+            } catch (e) {
+                if (e !== BREAK || x.target !== n.target) {
+                    throw e;    
+                }
             }
             break;
 
@@ -846,16 +880,18 @@ Narcissus.interpreter = (function() {
             v = {};
             c = n.children;
             for (i = 0, j = c.length; i < j; i++) {
-                t = c[i];
-                if (t.type === PROPERTY_INIT) {
-                    let c2 = t.children;
-                    v[c2[0].value] = getValue(execute(c2[1], x));
-                } else {
-                    f = newFunction(t, x);
-                    u = (t.type === GETTER) ? '__defineGetter__'
-                                            : '__defineSetter__';
-                    v[u](t.name, thunk(f, x));
-                }
+                (function(){
+                    t = c[i];
+                    if (t.type === PROPERTY_INIT) {
+                        var c2 = t.children;
+                        v[c2[0].value] = getValue(execute(c2[1], x));
+                    } else {
+                        f = newFunction(t, x);
+                        u = (t.type === GETTER) ? '__defineGetter__'
+                                                : '__defineSetter__';
+                        v[u](t.name, thunk(f, x));
+                    }
+                })();
             }
             break;
 
@@ -961,8 +997,12 @@ Narcissus.interpreter = (function() {
 
             try {
                 x2.execute(f.body);
-            } catch (e if e === RETURN) {
-                return x2.result;
+            } catch (e) {
+                if (e === RETURN) {
+                    return x2.result;
+                } else {
+                    throw e;
+                }
             }
             return undefined;
         },
@@ -1172,22 +1212,24 @@ Narcissus.interpreter = (function() {
             try {
                 execute(parser.parseStdin(src, ln), x);
                 display(x.result);
-            } catch (e if e === THROW) {
-                print("uncaught exception: " + string(x.result));
-            } catch (e if e === END) {
-                break;
-            } catch (e if e instanceof SyntaxError) {
-                const PREFIX = (e.filename || "stdin") + ":" + e.lineNumber + ": ";
-                print(PREFIX + e.toString());
-                print(PREFIX + e.source);
-                print(PREFIX + ".".repeat(e.cursor) + "^");
-            } catch (e if e instanceof Error) {
-                print((e.filename || "stdin") + ":" +  e.lineNumber + ": " + e.toString());
-                if (e.stack)
-                    printStackTrace(e.stack);
             } catch (e) {
-                print("unexpected Narcissus exception (" + e + ")");
-                throw e;
+                if (e === THROW) {
+                    print("uncaught exception: " + string(x.result));
+                } else if (e === END) {
+                    break;
+                } else if (e instanceof SyntaxError) {
+                    const PREFIX = (e.filename || "stdin") + ":" + e.lineNumber + ": ";
+                    print(PREFIX + e.toString());
+                    print(PREFIX + e.source);
+                    print(PREFIX + ".".repeat(e.cursor) + "^");
+                } else if (e instanceof Error) {
+                    print((e.filename || "stdin") + ":" +  e.lineNumber + ": " + e.toString());
+                    if (e.stack)
+                        printStackTrace(e.stack);
+                } else {
+                    print("unexpected Narcissus exception (" + e + ")");
+                    throw e;
+                }
             }
         }
         ExecutionContext.current = null;

--- a/lib/jsexec.js
+++ b/lib/jsexec.js
@@ -55,6 +55,9 @@
  */
 
 Narcissus.interpreter = (function() {
+    if (typeof Proxy === 'undefined' && typeof require === 'function') {
+        var Proxy = require('node-proxy');
+    }
 
     var parser = Narcissus.parser;
     var definitions = Narcissus.definitions;
@@ -237,22 +240,22 @@ Narcissus.interpreter = (function() {
 
     function resetEnvironment() {
         ExecutionContext.current = new ExecutionContext(GLOBAL_CODE, Narcissus.options.version);
-        let names = Object.getOwnPropertyNames(global);
-        for (let i = 0, n = names.length; i < n; i++) {
+        var names = Object.getOwnPropertyNames(global);
+        for (var i = 0, n = names.length; i < n; i++) {
             delete global[names[i]];
         }
-        for (let key in globalScope) {
+        for (var key in globalScope) {
             delete globalScope[key];
         }
         moduleInstances = new WeakMap();
         globalStaticEnv = new StaticEnv();
 
-        let names = Object.getOwnPropertyNames(hostProxy);
-        for (let i = 0, n = names.length; i < n; i++) {
+        var names = Object.getOwnPropertyNames(hostProxy);
+        for (var i = 0, n = names.length; i < n; i++) {
             globalStaticEnv.bind(names[i], new Def());
         }
-        for (let key in globalBase) {
-            let val = globalBase[key];
+        for (var key in globalBase) {
+            var val = globalBase[key];
             global[key] = val;
             globalScope[key] = val;
             // NB: this assumes globalBase never contains module or import bindings
@@ -557,8 +560,12 @@ Narcissus.interpreter = (function() {
                         if (t.statements.children.length) {
                             try {
                                 execute(t.statements, x);
-                            } catch (e if e === BREAK_SIGNAL && x.target === n) {
-                                break switch_loop;
+                            } catch (e) {
+                                if (e === BREAK_SIGNAL && x.target === n) {
+                                    break switch_loop;
+                                } else {
+                                    throw e;
+                                }
                             }
                         }
                         if (++i === j)
@@ -577,10 +584,14 @@ Narcissus.interpreter = (function() {
             while (!n.condition || getValue(execute(n.condition, x))) {
                 try {
                     execute(n.body, x);
-                } catch (e if e === BREAK_SIGNAL && x.target === n) {
-                    break;
-                } catch (e if e === CONTINUE_SIGNAL && x.target === n) {
-                    // Must run the update expression.
+                } catch (e) { 
+                    if (e === BREAK_SIGNAL && x.target === n) {
+                        break;
+                    } else if (e === CONTINUE_SIGNAL && x.target === n) {
+                        // Must run the update expression.
+                    } else {
+                        throw e;
+                    }
                 }
                 n.update && getValue(execute(n.update, x));
             }
@@ -605,10 +616,14 @@ Narcissus.interpreter = (function() {
                 putValue(execute(r, x), a[i], r);
                 try {
                     execute(n.body, x);
-                } catch (e if e === BREAK_SIGNAL && x.target === n) {
-                    break;
-                } catch (e if e === CONTINUE_SIGNAL && x.target === n) {
-                    continue;
+                } catch (e) {
+                    if (e === BREAK_SIGNAL && x.target === n) {
+                        break;
+                    } else if (e === CONTINUE_SIGNAL && x.target === n) {
+                        continue;
+                    } else {
+                        throw e;
+                    }
                 }
             }
             break;
@@ -617,10 +632,14 @@ Narcissus.interpreter = (function() {
             do {
                 try {
                     execute(n.body, x);
-                } catch (e if e === BREAK_SIGNAL && x.target === n) {
-                    break;
-                } catch (e if e === CONTINUE_SIGNAL && x.target === n) {
-                    continue;
+                } catch (e) {
+                    if (e === BREAK_SIGNAL && x.target === n) {
+                        break;
+                    } else if (e === CONTINUE_SIGNAL && x.target === n) {
+                        continue;
+                    } else {
+                        throw e;
+                    }
                 }
             } while (getValue(execute(n.condition, x)));
             break;
@@ -636,22 +655,26 @@ Narcissus.interpreter = (function() {
           case TRY:
             try {
                 execute(n.tryBlock, x);
-            } catch (e if !(e instanceof InternalSignal) && (j = n.catchClauses.length)) {
-                x.result = undefined;
-                for (i = 0; ; i++) {
-                    if (i === j)
-                        throw e;
-                    t = n.catchClauses[i];
-                    x.scope = {object: {}, parent: x.scope};
-                    definitions.defineProperty(x.scope.object, t.varName, e, true);
-                    try {
-                        if (t.guard && !getValue(execute(t.guard, x)))
-                            continue;
-                        execute(t.block, x);
-                        break;
-                    } finally {
-                        x.scope = x.scope.parent;
+            } catch (e) {
+                if (!(e instanceof InternalSignal) && (j = n.catchClauses.length)) {
+                    x.result = undefined;
+                    for (i = 0; ; i++) {
+                        if (i === j)
+                            throw e;
+                        t = n.catchClauses[i];
+                        x.scope = {object: {}, parent: x.scope};
+                        definitions.defineProperty(x.scope.object, t.varName, e, true);
+                        try {
+                            if (t.guard && !getValue(execute(t.guard, x)))
+                                continue;
+                            execute(t.block, x);
+                            break;
+                        } finally {
+                            x.scope = x.scope.parent;
+                        }
                     }
+                } else {
+                    throw e;
                 }
             } finally {
                 if (n.finallyBlock)
@@ -709,7 +732,10 @@ Narcissus.interpreter = (function() {
           case LABEL:
             try {
                 execute(n.statement, x);
-            } catch (e if e === BREAK_SIGNAL && x.target === n.target) {
+            } catch (e) {
+                if (e !== BREAK_SIGNAL || x.target !== n.target) {
+                    throw e;    
+                }
             }
             break;
 
@@ -989,16 +1015,18 @@ Narcissus.interpreter = (function() {
             v = {};
             c = n.children;
             for (i = 0, j = c.length; i < j; i++) {
-                t = c[i];
-                if (t.type === PROPERTY_INIT) {
-                    let c2 = t.children;
-                    v[c2[0].value] = getValue(execute(c2[1], x));
-                } else {
-                    f = newFunction(t, x);
-                    u = (t.type === GETTER) ? '__defineGetter__'
-                                            : '__defineSetter__';
-                    v[u](t.name, thunk(f, x));
-                }
+                (function(){
+                    t = c[i];
+                    if (t.type === PROPERTY_INIT) {
+                        var c2 = t.children;
+                        v[c2[0].value] = getValue(execute(c2[1], x));
+                    } else {
+                        f = newFunction(t, x);
+                        u = (t.type === GETTER) ? '__defineGetter__'
+                                                : '__defineSetter__';
+                        v[u](t.name, thunk(f, x));
+                    }
+                })();
             }
             break;
 
@@ -1227,8 +1255,12 @@ Narcissus.interpreter = (function() {
             x2.scope = {object: new Activation(n, a), parent: this.scope};
             try {
                 x2.execute(n.body);
-            } catch (e if e === RETURN_SIGNAL) {
-                return x2.result;
+            } catch (e) {
+                if (e === RETURN_SIGNAL) {
+                    return x2.result;
+                } else {
+                    throw e;
+                }
             }
             return undefined;
         },
@@ -1392,21 +1424,23 @@ Narcissus.interpreter = (function() {
                 }
                 execute(ast, x);
                 display(x.result);
-            } catch (e if e === EXIT_SIGNAL) {
-                break;
-            } catch (e if e === CANCEL_SIGNAL) {
-                continue;
-            } catch (e if e instanceof SyntaxError) {
-                const PREFIX = (e.filename || "stdin") + ":" + e.lineNumber + ": ";
-                print(PREFIX + e.toString());
-                print(PREFIX + e.source);
-                print(PREFIX + ".".repeat(e.cursor) + "^");
-            } catch (e if e instanceof Error) {
-                print((e.filename || "stdin") + ":" +  e.lineNumber + ": " + e.toString());
-                if (e.stack)
-                    printStackTrace(e.stack);
             } catch (e) {
-                print("uncaught exception: " + string(e));
+                if (e === EXIT_SIGNAL) {
+                    break;
+                } else if (e === CANCEL_SIGNAL) {
+                    continue;
+                } else if (e instanceof SyntaxError) {
+                    const PREFIX = (e.filename || "stdin") + ":" + e.lineNumber + ": ";
+                    print(PREFIX + e.toString());
+                    print(PREFIX + e.source);
+                    print(PREFIX + ".".repeat(e.cursor) + "^");
+                } else if (e instanceof Error) {
+                    print((e.filename || "stdin") + ":" +  e.lineNumber + ": " + e.toString());
+                    if (e.stack)
+                        printStackTrace(e.stack);
+                } else {
+                    print("uncaught exception: " + string(e));
+                }
             }
         }
         ExecutionContext.current = null;

--- a/lib/jsresolve.js
+++ b/lib/jsresolve.js
@@ -99,17 +99,17 @@ Narcissus.resolver = (function() {
         },
 
         lookup: function(x) {
-            let env = this;
+            var env = this;
             while (env && !env.frame.has(x))
                 env = env.parent;
-            let def = env && env.frame.get(x);
+            var def = env && env.frame.get(x);
             if (!def)
                 throw new ReferenceError("unbound reference to " + x);
             return def;
         },
 
         hoistBarrier: function(x) {
-            let env = this;
+            var env = this;
             while (!env.isScriptFrame()) {
                 if (env.frame.has(x))
                     return env.frame.get(x);
@@ -143,15 +143,15 @@ Narcissus.resolver = (function() {
 
     // resolveScript :: (SCRIPT node, StaticEnv) -> void
     function resolveScript(node, env) {
-        let funDecls = node.funDecls;
-        for (let i = 0; i < funDecls.length; i++) {
-            let decl = funDecls[i];
+        var funDecls = node.funDecls;
+        for (var i = 0; i < funDecls.length; i++) {
+            var decl = funDecls[i];
             env.bind(decl.name, new Def(FUN_DEF, decl));
         }
 
-        let varDecls = node.varDecls;
-        for (let i = 0; i < varDecls.length; i++) {
-            let decl = varDecls[i];
+        var varDecls = node.varDecls;
+        for (var i = 0; i < varDecls.length; i++) {
+            var decl = varDecls[i];
             env.bind(decl.name, new Def(VAR_DEF, decl));
         }
 
@@ -215,7 +215,7 @@ Narcissus.resolver = (function() {
     }
 
     function resolveCatch(node, env) {
-        let env2 = new StaticEnv(env, CATCH_FRAME);
+        var env2 = new StaticEnv(env, CATCH_FRAME);
 
         // BUG 620819: handle destructuring
         env2.bind(node.varName, new Def(CATCH_DEF, node));
@@ -246,9 +246,9 @@ Narcissus.resolver = (function() {
     }
 
     function bindImports(impDecls, env) {
-        for (let i = 0; i < impDecls.length; i++) {
-            let list = impDecls[i].pathList;
-            for (let j = 0; j < list.length; j++)
+        for (var i = 0; i < impDecls.length; i++) {
+            var list = impDecls[i].pathList;
+            for (var j = 0; j < list.length; j++)
                 bindImport(list[j], env);
         }
     }
@@ -303,7 +303,7 @@ Narcissus.resolver = (function() {
 
     function bindModuleRedeclarations(modDecls, env) {
         modDecls.forEach(function(name, node) {
-            let def = env.lookup(name);
+            var def = env.lookup(name);
             if (def.type !== MODULE_DEF)
                 throw new ReferenceError("attempt to redeclare variable " + name + " as a module");
             env.bindUnique(name, def);
@@ -314,19 +314,19 @@ Narcissus.resolver = (function() {
         var workSet = modAssns.copy();
 
         function bindAssn(assn, dependents) {
-            let localID = assn.value;
+            var localID = assn.value;
 
             if (!assn.initializer) {
                 env.bindUnique(localID, new Def(MODULE_DEF, resolveModulePath(env, localID)));
                 return;
             }
 
-            let headID = pathHead(assn.initializer);
+            var headID = pathHead(assn.initializer);
             if (dependents.has(headID))
                 throw new ReferenceError("cyclic dependency in module expression: " +
                                          cycleToString(dependents));
             if (workSet.has(headID)) {
-                let assn2 = workSet.get(headID);
+                var assn2 = workSet.get(headID);
                 workSet.remove(headID);
                 dependents.set(headID, true);
                 bindAssn(assn2, dependents);
@@ -336,10 +336,10 @@ Narcissus.resolver = (function() {
         }
 
         while (workSet.size > 0) {
-            let id = workSet.choose();
-            let assn = workSet.get(id);
+            var id = workSet.choose();
+            var assn = workSet.get(id);
             workSet.remove(id);
-            let dependents = new Dict();
+            var dependents = new Dict();
             dependents.set(id, true);
             bindAssn(assn, dependents);
         }
@@ -354,7 +354,7 @@ Narcissus.resolver = (function() {
     // resolveModule :: (MODULE node, StaticEnv) -> void
     function resolveModule(node, env) {
         if (node.body) {
-            let env2 = new StaticEnv(env, MODULE_FRAME);
+            var env2 = new StaticEnv(env, MODULE_FRAME);
             node.module.env = env2;
             resolveScript(node.body, env2);
         }
@@ -362,12 +362,12 @@ Narcissus.resolver = (function() {
 
     // resolveFunction :: (FUNCTION node, StaticEnv) -> void
     function resolveFunction(node, env) {
-        let env2 = new StaticEnv(env, FUNCTION_FRAME);
+        var env2 = new StaticEnv(env, FUNCTION_FRAME);
         if (node.name && node.functionForm === parser.EXPRESSED_FORM)
             env2.bind(node.name, new Def(FUN_DEF, node));
 
         // BUG 620819: handle destructuring
-        for (let i = 0; i < node.params.length; i++)
+        for (var i = 0; i < node.params.length; i++)
             env2.bind(node.params[i], new Def(ARG_DEF));
 
         resolveScript(node.body, env2);
@@ -455,7 +455,7 @@ Narcissus.resolver = (function() {
               case DOT:
               case INDEX:
               {
-                let def = resolvePath(node, env);
+                var def = resolvePath(node, env);
                 if (def)
                     throw new SyntaxError("attempt to delete module import");
                 break;
@@ -477,7 +477,7 @@ Narcissus.resolver = (function() {
 
           case COMMA:
           case LIST:
-            for (let i in node.children)
+            for (var i in node.children)
                 resolveExpression(node.children[i], env);
             break;
 
@@ -497,15 +497,15 @@ Narcissus.resolver = (function() {
             break;
 
           case ARRAY_INIT:
-            for (let i in node.children) {
-                let elt = node.children[i];
+            for (var i in node.children) {
+                var elt = node.children[i];
                 if (elt)
                     resolveExpression(elt, env);
             }
             break;
 
           case OBJECT_INIT:
-            for (let i in node.children)
+            for (var i in node.children)
                 resolveExpression(node.children[i].children[1], env);
             break;
 
@@ -568,21 +568,21 @@ Narcissus.resolver = (function() {
     // resolveVariables :: (VAR node, StaticEnv) -> void
     function resolveVariables(node, env) {
         // BUG 620819: handle destructuring
-        let children = node.children;
+        var children = node.children;
 
-        for (let i = 0; i < children.length; i++) {
-            let name = children[i].name;
+        for (var i = 0; i < children.length; i++) {
+            var name = children[i].name;
             if (env.hoistBarrier(name))
                 throw new Error("illegal redeclaration of local variable " + name);
-            let init = children[i].initializer;
+            var init = children[i].initializer;
             if (init)
                 resolveExpression(init, env);
         }
     }
 
     function resolveStatements(node, env) {
-        let children = node.children;
-        for (let i = 0; i < children.length; i++)
+        var children = node.children;
+        for (var i = 0; i < children.length; i++)
             resolveStatement(children[i], env);
     }
 
@@ -646,8 +646,8 @@ Narcissus.resolver = (function() {
 
           case SWITCH:
             resolveExpression(node.discriminant, env);
-            for (let i = 0; i < node.cases.length; i++) {
-                let caseNode = node.cases[i];
+            for (var i = 0; i < node.cases.length; i++) {
+                var caseNode = node.cases[i];
                 if (caseNode.caseLabel)
                     resolveExpression(caseNode.caseLabel, env);
                 resolveStatement(caseNode.statements, env);
@@ -687,7 +687,7 @@ Narcissus.resolver = (function() {
 
           case TRY:
             resolveStatement(node.tryBlock, env);
-            for (let i = 0; i < node.catchClauses.length; i++)
+            for (var i = 0; i < node.catchClauses.length; i++)
                 resolveCatch(node.catchClauses[i], env);
             if (node.finallyBlock)
                 resolveStatement(node.finallyBlock, env);

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "version": "0.0.1",
   "author": "Mozilla",
   "directories": {"lib": "./lib"},
-  "main": "main.js"
+  "main": "main.js",
+  "dependencies": {
+    "node-proxy": "*"
+  }
 }


### PR DESCRIPTION
Hi,

Not sure if this is useful to you or not, but I noticed narcissus has an NPM package that doesn't include the interpreter. I added it to the list of exported modules, and then fixed errors in jsexec and jsresolve by replacing `let`s with `var`s and factoring `catch e if` into separate `catch` and `if` blocks with rethrows.

Node (at least, the version I'm using) doesn't support harmony proxies yet, but there's an npm module called node-proxy that implements them, so I added that to the package dependencies.

I'm a little confused about tests, though. `jstests` needs a jstests.py which I don't have, and presumably a directory of tests that I also don't have. Should I look somewhere for them?

I get the same pattern of successes and failures from the harmony tests, and my ghetto testing looks promising:

```
> require('./main.js').interpreter.evaluate("2+2");
4
```
