### PR TITLE
Improve tracking of token end position

### DIFF
--- a/lib/jsparse.js
+++ b/lib/jsparse.js
@@ -581,7 +581,11 @@ Narcissus.parser = (function() {
             n.condition = HeadExpression(t, x);
             x2 = x.pushTarget(n).nest();
             n.thenPart = Statement(t, x2);
-            n.elsePart = t.match(ELSE, true) ? Statement(t, x2) : null;
+            n.end = t.cursor;
+            if (t.match(ELSE, true)) {
+                n.elsePart = Statement(t, x2);
+                n.end = t.cursor;
+            }
             return n;
 
           case SWITCH:
@@ -859,6 +863,7 @@ Narcissus.parser = (function() {
 
         n.blockComments = comments;
         MagicalSemicolon(t);
+        n.end = t.cursor;
         return n;
     }
 
@@ -1691,6 +1696,7 @@ Narcissus.parser = (function() {
                     n2 = new Node(t, { type: CALL });
                     n2.push(n);
                     n2.push(ArgumentList(t, x));
+                    n2.end = t.cursor;
                     break;
                 }
 
@@ -1758,6 +1764,7 @@ Narcissus.parser = (function() {
                 n = n2;
             }
             t.mustMatch(RIGHT_BRACKET);
+            n.end = t.cursor;
             break;
 
           case LEFT_CURLY:
@@ -1807,6 +1814,7 @@ Narcissus.parser = (function() {
                 } while (t.match(COMMA));
                 t.mustMatch(RIGHT_CURLY);
             }
+            n.end = t.cursor;
             break;
 
           case LEFT_PAREN:


### PR DESCRIPTION
In a few places, the token end position was not properly tracked, and didn't
cover the entire span of the source code that the node represents. This improves
the tracking in several places where I noticed it was wrong.
