### PR TITLE
eliminate tokenizer from parse nodes

### DIFF
--- a/lib/interpreter.js
+++ b/lib/interpreter.js
@@ -1222,12 +1222,10 @@ var FIp = FunctionInternals.prototype = {
 
     toString: function() {
         var parenthesized = this.node.parenthesized;
-        try {
-            this.node.parenthesized = false;
-            return decompiler.pp(this.node);
-        } finally {
-            this.node.parenthesized = parenthesized;
-        }
+        this.node.parenthesized = false;
+        var result = decompiler.pp(this.node);
+        this.node.parenthesized = parenthesized;
+        return result;
     }
 };
 

--- a/lib/interpreter.js
+++ b/lib/interpreter.js
@@ -61,6 +61,7 @@ var resolver = require('./resolver');
 var hostGlobal = require('./global');
 var desugaring = require('./desugaring');
 var bytecode = require('./bytecode');
+var decompiler = require('./decompiler');
 
 // Set constants in the local scope.
 eval(definitions.consts);
@@ -282,7 +283,9 @@ function Reference(base, propertyName, node) {
     this.node = node;
 }
 
-Reference.prototype.toString = function () { return this.node.getSource(); }
+Reference.prototype.toString = function () {
+    return decompiler.pp(this.node);
+}
 
 function getValue(v) {
     if (v instanceof Reference) {
@@ -1218,7 +1221,13 @@ var FIp = FunctionInternals.prototype = {
     },
 
     toString: function() {
-        return this.node.getSource();
+        var parenthesized = this.node.parenthesized;
+        try {
+            this.node.parenthesized = false;
+            return decompiler.pp(this.node);
+        } finally {
+            this.node.parenthesized = parenthesized;
+        }
     }
 };
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -251,8 +251,7 @@ function Node(t, init) {
         this.lineno = t.lineno;
     }
 
-    // Node uses a tokenizer for debugging (getSource, filename getter).
-    this.tokenizer = t;
+    this.filename = t.filename;
     this.children = [];
 
     for (var prop in init)
@@ -260,10 +259,9 @@ function Node(t, init) {
 }
 
 /*
- * SyntheticNode :: (tokenizer, optional init object) -> node
+ * SyntheticNode :: (optional init object) -> node
  */
-function SyntheticNode(t, init) {
-    this.tokenizer = t;
+function SyntheticNode(init) {
     this.children = [];
     for (var prop in init)
         this[prop] = init[prop];
@@ -356,12 +354,8 @@ Np.toString = function () {
     return s;
 }
 
-Np.getSource = function () {
-    return this.tokenizer.source.slice(this.start, this.end);
-};
-
 Np.synth = function(init) {
-    var node = new SyntheticNode(this.tokenizer, init);
+    var node = new SyntheticNode(init);
     node.filename = this.filename;
     node.lineno = this.lineno;
     node.start = this.start;
@@ -394,11 +388,6 @@ function scriptInit() {
              hasReturnWithValue: false,
              hasYield: false };
 }
-
-definitions.defineGetter(Np, "filename",
-                         function() {
-                             return this.tokenizer.filename;
-                         });
 
 definitions.defineGetter(Np, "length",
                          function() {
@@ -707,7 +696,7 @@ Pp.Statement = function Statement() {
                     if (c.length !== 1 && n2.destructurings.length !== 1) {
                         // FIXME: this.fail ?
                         throw new SyntaxError("Invalid for..in left-hand side",
-                                              this.t.filename, n2.lineno);
+                                              this.filename, n2.lineno);
                     }
                     if (n2.destructurings.length > 0) {
                         n.iterator = n2.destructurings[0];


### PR DESCRIPTION
This patch addresses bug 584796:

```
https://bugzilla.mozilla.org/show_bug.cgi?id=584796
```

Dave
