### PR TITLE
strings containing new lines are not considered invalid 

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -363,6 +363,8 @@ Tokenizer.prototype = {
         if (input.length <= this.cursor)
             throw this.newSyntaxError("Unterminated string literal");
         while ((ch = input[this.cursor++]) !== delim) {
+            if (ch == '\n' || ch == '\r')
+                throw this.newSyntaxError("Unterminated string literal");
             if (this.cursor == input.length)
                 throw this.newSyntaxError("Unterminated string literal");
             if (ch === '\\') {


### PR DESCRIPTION
```
require("narcissus/parser").parse('"\n\\n"')
```

is considered a valid string, which results in an uncaught exceptions in the eval

``` javascript
token.value = hasEscapes
            ? eval(input.substring(token.start, this.cursor))
            : input.substring(token.start + 1, this.cursor - 1);
```

This patch catches unescaped new lines and throws the expected syntax error.
