### PR TITLE
Allow lexer to be used independently of the parser

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -130,6 +130,8 @@ function Tokenizer(s, f, l, allowHTMLComments) {
     this.lineno = l || 1;
     this.allowHTMLComments = allowHTMLComments;
     this.blockComments = null;
+    this.strictMode = false;
+    this.mozillaMode = false;
 }
 
 Tokenizer.prototype = {
@@ -458,7 +460,7 @@ Tokenizer.prototype = {
 
         var kw;
 
-        if (this.parser.mozillaMode) {
+        if (this.mozillaMode) {
             kw = definitions.mozillaKeywords[id];
             if (kw) {
                 token.type = kw;
@@ -466,7 +468,7 @@ Tokenizer.prototype = {
             }
         }
 
-        if (this.parser.x.strictMode) {
+        if (this.strictMode) {
             kw = definitions.strictKeywords[id];
             if (kw) {
                 token.type = kw;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -77,11 +77,10 @@ function pushDestructuringVarDecls(n, s) {
 }
 
 function Parser(tokenizer) {
-    tokenizer.parser = this;
     this.t = tokenizer;
     this.x = null;
     this.unexpectedEOF = false;
-    options.mozillaMode && (this.mozillaMode = true);
+    options.mozillaMode && (tokenizer.mozillaMode = this.mozillaMode = true);
     options.parenFreeMode && (this.parenFreeMode = true);
 }
 
@@ -426,7 +425,7 @@ Pp.Statements = function Statements(n, topLevel) {
             var n2 = this.Statement();
             n.push(n2);
             if (prologue && Pragma(n2)) {
-                this.x.strictMode = true;
+                this.t.strictMode = this.x.strictMode = true;
                 n.strict = true;
             } else {
                 prologue = false;


### PR DESCRIPTION
Presently, if you run the following code, it will throw an error:

``` js
var tokenizer = new (require('narcissus').lexer.Tokenizer)('foo()');
tokenizer.get();
```

This is because the lexer is looking for a reference to an instance of a parser. This pull request makes it so that the lexer does not rely on the parser to function, allowing tools to parse and lex code separately.

This could be worked around by inserting something like this:

``` js
tokenizer.parser = {mozillaMode: false, x: {}};
```

...but that's pretty jank and this fixes the root of the issue.
