### PR TITLE
fix parsInt: which doesn't work for octal numbers without radix

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -303,7 +303,7 @@ Tokenizer.prototype = {
             } while (ch >= '0' && ch <= '7');
             this.cursor--;
 
-            token.value = parseInt(input.substring(token.start, this.cursor));
+            token.value = parseInt(input.substring(token.start, this.cursor), 8);
         } else {
             this.cursor--;
             this.lexExponent();     // 0E1, &c.


### PR DESCRIPTION
`parseInt` does not understand octal numbers, for example:`parseInt('0777')` is `777`
