### PR TITLE
isValidIdentifierChar: improve metacircular character test

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -84,15 +84,10 @@ function isValidIdentifierChar(ch, first) {
         return false;
     }
 
-    // create an object to test this in
-    var x = {};
-    x["x"+ch] = true;
-    x[ch] = true;
-
-    // then use eval to determine if it's a valid character
+    // use eval to determine if it's a valid character
     var valid = false;
     try {
-        valid = (Function("x", "return (x." + (first?"":"x") + ch + ");")(x) === true);
+        valid = eval("({})." + (first ? "" : "x") + ch + " = true;");
     } catch (ex) {}
 
     return valid;


### PR DESCRIPTION
I'm assuming that the rather verbose assignment was added in order not do pollute the global namespace... but in fact, the object property test can be accomplished without any assignment at all.

These changes are of course purely cosmetic, but I'd argue that this particular function deserves it.
