### PR TITLE
FIX: redeclaration of "let names"

### DIFF
--- a/lib/interpreter.js
+++ b/lib/interpreter.js
@@ -215,7 +215,7 @@ function resetEnvironment() {
     moduleInstances = new WeakMap();
     globalStaticEnv = new StaticEnv();
 
-    let names = Object.getOwnPropertyNames(hostProxy);
+    names = Object.getOwnPropertyNames(hostProxy);
     for (let i = 0, n = names.length; i < n; i++) {
         globalStaticEnv.bind(names[i], new Def());
     }


### PR DESCRIPTION
It's not valid ES6 code now, `let names` should only declare once.
